### PR TITLE
Add XMLChoiceKey and XMLSingleElementEncodingContainer

### DIFF
--- a/Sources/XMLCoder/Auxiliaries/Box/SingleElementBox.swift
+++ b/Sources/XMLCoder/Auxiliaries/Box/SingleElementBox.swift
@@ -9,8 +9,8 @@
 /// an element nested in a keyed or unkeyed container, or an choice between multiple known-typed values (implemented in Swift using
 /// enums with associated values).
 struct SingleElementBox: SimpleBox {
-    let key: String
-    let element: Box
+    var key: String
+    var element: Box
 }
 
 extension SingleElementBox: Box {

--- a/Sources/XMLCoder/Auxiliaries/Box/SingleElementBox.swift
+++ b/Sources/XMLCoder/Auxiliaries/Box/SingleElementBox.swift
@@ -14,8 +14,8 @@ struct SingleElementBox: SimpleBox {
     typealias Attributes = KeyedStorage<Key, Attribute>
     
     var attributes = Attributes()
-    var key: String
-    var element: Box
+    var key: String = ""
+    var element: Box = NullBox()
 }
 
 extension SingleElementBox: Box {

--- a/Sources/XMLCoder/Auxiliaries/Box/SingleElementBox.swift
+++ b/Sources/XMLCoder/Auxiliaries/Box/SingleElementBox.swift
@@ -9,6 +9,11 @@
 /// an element nested in a keyed or unkeyed container, or an choice between multiple known-typed values (implemented in Swift using
 /// enums with associated values).
 struct SingleElementBox: SimpleBox {
+    typealias Key = String
+    typealias Attribute = SimpleBox
+    typealias Attributes = KeyedStorage<Key, Attribute>
+    
+    var attributes = Attributes()
     var key: String
     var element: Box
 }

--- a/Sources/XMLCoder/Auxiliaries/XMLChoiceKey.swift
+++ b/Sources/XMLCoder/Auxiliaries/XMLChoiceKey.swift
@@ -5,4 +5,4 @@
 //  Created by Benjamin Wetherfield on 7/17/19.
 //
 
-public protocol XMLChoiceKey {}
+public protocol XMLChoiceKey: CodingKey {}

--- a/Sources/XMLCoder/Auxiliaries/XMLChoiceKey.swift
+++ b/Sources/XMLCoder/Auxiliaries/XMLChoiceKey.swift
@@ -1,0 +1,8 @@
+//
+//  XMLChoiceKey.swift
+//  XMLCoder
+//
+//  Created by Benjamin Wetherfield on 7/17/19.
+//
+
+public protocol XMLChoiceKey {}

--- a/Sources/XMLCoder/Auxiliaries/XMLCoderElement.swift
+++ b/Sources/XMLCoder/Auxiliaries/XMLCoderElement.swift
@@ -257,6 +257,12 @@ extension XMLCoderElement {
     }
 
     init(key: String, box: UnkeyedBox) {
+        if let first = box.first {
+            if first is SingleElementBox {
+                self.init(key: key, elements: box.map { XMLCoderElement(key: "", box: $0) })
+                return
+            }
+        }
         self.init(key: key, elements: box.map {
             XMLCoderElement(key: key, box: $0)
         })

--- a/Sources/XMLCoder/Auxiliaries/XMLCoderElement.swift
+++ b/Sources/XMLCoder/Auxiliaries/XMLCoderElement.swift
@@ -261,6 +261,10 @@ extension XMLCoderElement {
             XMLCoderElement(key: key, box: $0)
         })
     }
+    
+    init(key: String, box: SingleElementBox) {
+        self.init(key: key, elements: [XMLCoderElement(key: key, box: box.element)])
+    }
 
     init(key: String, box: KeyedBox) {
         var elements: [XMLCoderElement] = []
@@ -314,10 +318,14 @@ extension XMLCoderElement {
             self.init(key: key, box: sharedUnkeyedBox.unboxed)
         case let sharedKeyedBox as SharedBox<KeyedBox>:
             self.init(key: key, box: sharedKeyedBox.unboxed)
+        case let sharedSingleElementBox as SharedBox<SingleElementBox>:
+            self.init(key: key, box: sharedSingleElementBox.unboxed)
         case let unkeyedBox as UnkeyedBox:
             self.init(key: key, box: unkeyedBox)
         case let keyedBox as KeyedBox:
             self.init(key: key, box: keyedBox)
+        case let singleElementBox as SingleElementBox:
+            self.init(key: key, box: singleElementBox)
         case let simpleBox as SimpleBox:
             self.init(key: key, box: simpleBox)
         case let box:

--- a/Sources/XMLCoder/Auxiliaries/XMLCoderElement.swift
+++ b/Sources/XMLCoder/Auxiliaries/XMLCoderElement.swift
@@ -53,7 +53,7 @@ struct XMLCoderElement: Equatable {
 
     func transformToBoxTree() -> Box {
         if let value = value, self.attributes.isEmpty, self.elements.isEmpty {
-            return SingleElementBox(key: key, element: StringBox(value))
+            return SingleElementBox(attributes: SingleElementBox.Attributes(), key: key, element: StringBox(value))
         }
         let attributes = KeyedStorage(self.attributes.map { attribute in
             (key: attribute.key, value: StringBox(attribute.value) as SimpleBox)

--- a/Sources/XMLCoder/Auxiliaries/XMLCoderElement.swift
+++ b/Sources/XMLCoder/Auxiliaries/XMLCoderElement.swift
@@ -263,7 +263,7 @@ extension XMLCoderElement {
     }
     
     init(key: String, box: SingleElementBox) {
-        self.init(key: key, elements: [XMLCoderElement(key: key, box: box.element)])
+        self.init(key: key, elements: [XMLCoderElement(key: box.key, box: box.element)])
     }
 
     init(key: String, box: KeyedBox) {

--- a/Sources/XMLCoder/Auxiliaries/XMLCoderElement.swift
+++ b/Sources/XMLCoder/Auxiliaries/XMLCoderElement.swift
@@ -250,11 +250,6 @@ struct XMLCoderElement: Equatable {
 // MARK: - Convenience Initializers
 
 extension XMLCoderElement {
-    /// Creates an `XMLCoderElement` for collections of `XMLChoiceEncodable`-conforming types wherein the key for each
-    /// element contained therein is ommitted.
-    static func ommittingNestedElementKeys(key: String, box: UnkeyedBox) -> XMLCoderElement {
-        return XMLCoderElement(key: key, elements: box.map { XMLCoderElement(key: "", box: $0) })
-    }
 
     init(key: String, box: UnkeyedBox) {
         if let first = box.first {

--- a/Sources/XMLCoder/Auxiliaries/XMLCoderElement.swift
+++ b/Sources/XMLCoder/Auxiliaries/XMLCoderElement.swift
@@ -252,15 +252,11 @@ struct XMLCoderElement: Equatable {
 extension XMLCoderElement {
 
     init(key: String, box: UnkeyedBox) {
-        if let first = box.first {
-            if first is SingleElementBox {
-                self.init(key: key, elements: box.map { XMLCoderElement(key: "", box: $0) })
-                return
-            }
+        if box is [SingleElementBox] {
+            self.init(key: key, elements: box.map { XMLCoderElement(key: "", box: $0) })
+        } else {
+            self.init(key: key, elements: box.map { XMLCoderElement(key: key, box: $0) })
         }
-        self.init(key: key, elements: box.map {
-            XMLCoderElement(key: key, box: $0)
-        })
     }
     
     init(key: String, box: SingleElementBox) {

--- a/Sources/XMLCoder/Decoder/XMLDecoderImplementation.swift
+++ b/Sources/XMLCoder/Decoder/XMLDecoderImplementation.swift
@@ -140,7 +140,10 @@ class XMLDecoderImplementation: Decoder {
         case let keyed as SharedBox<KeyedBox>:
             return XMLUnkeyedDecodingContainer(
                 referencing: self,
-                wrapping: SharedBox(keyed.withShared { $0.elements.map(SingleElementBox.init) })
+                wrapping: SharedBox(keyed.withShared { $0.elements.map { key, box in
+                    SingleElementBox(attributes: SingleElementBox.Attributes(), key: key, element: box)
+                    }
+                })
             )
         default:
             throw DecodingError.typeMismatch(

--- a/Sources/XMLCoder/Encoder/XMLEncoder.swift
+++ b/Sources/XMLCoder/Encoder/XMLEncoder.swift
@@ -338,6 +338,8 @@ open class XMLEncoder {
             elementOrNone = XMLCoderElement(key: rootKey, box: keyedBox)
         } else if let unkeyedBox = topLevel as? UnkeyedBox {
             elementOrNone = XMLCoderElement(key: rootKey, box: unkeyedBox)
+        } else if let singleElementBox = topLevel as? SingleElementBox {
+            elementOrNone = XMLCoderElement(key: rootKey, box: singleElementBox)
         } else {
             fatalError("Unrecognized top-level element of type: \(type(of: topLevel))")
         }

--- a/Sources/XMLCoder/Encoder/XMLEncoder.swift
+++ b/Sources/XMLCoder/Encoder/XMLEncoder.swift
@@ -357,48 +357,4 @@ open class XMLEncoder {
                                    formatting: outputFormatting)
             .data(using: .utf8, allowLossyConversion: true)!
     }
-
-    /// Encodes the given top-level value and returns its XML representation.
-    ///
-    /// - parameter value: The `Collection` of `XMLChoiceEncodable` values to encode.
-    /// - parameter withRootKey: the key used to wrap the encoded values.
-    /// - returns: A new `Data` value containing the encoded XML data.
-    /// - throws: `EncodingError.invalidValue` if a non-conforming
-    /// floating-point value is encountered during encoding, and the encoding
-    /// strategy is `.throw`.
-    /// - throws: An error if any value throws an error during encoding.
-    open func encode<T: Collection & Encodable>(
-        _ value: T, withRootKey rootKey: String,
-        header: XMLHeader? = nil
-    ) throws -> Data where T.Element: XMLChoiceEncodable {
-        let encoder = XMLEncoderImplementation(
-            options: options,
-            nodeEncodings: []
-        )
-        encoder.nodeEncodings.append(options.nodeEncodingStrategy.nodeEncodings(forType: T.self, with: encoder))
-
-        let topLevel = try encoder.box(value)
-
-        let elementOrNone: XMLCoderElement?
-        if let keyedBox = topLevel as? KeyedBox {
-            elementOrNone = XMLCoderElement(key: rootKey, box: keyedBox)
-        } else if let unkeyedBox = topLevel as? UnkeyedBox {
-            elementOrNone = XMLCoderElement.ommittingNestedElementKeys(key: rootKey, box: unkeyedBox)
-        } else {
-            fatalError("Unrecognized top-level element of type: \(type(of: topLevel))")
-        }
-
-        guard let element = elementOrNone else {
-            throw EncodingError.invalidValue(value, EncodingError.Context(
-                codingPath: [],
-                debugDescription: "Unable to encode the given top-level value to XML."
-            ))
-        }
-
-        let withCDATA = stringEncodingStrategy != .deferredToString
-        return element.toXMLString(with: header,
-                                   withCDATA: withCDATA,
-                                   formatting: outputFormatting)
-            .data(using: .utf8, allowLossyConversion: true)!
-    }
 }

--- a/Sources/XMLCoder/Encoder/XMLEncoderImplementation.swift
+++ b/Sources/XMLCoder/Encoder/XMLEncoderImplementation.swift
@@ -71,7 +71,7 @@ class XMLEncoderImplementation: Encoder {
         }
     }
     
-    open func keyedContainer<Key>(keyedBy _: Key.Type) -> KeyedEncodingContainer<Key> {
+    public func keyedContainer<Key>(keyedBy _: Key.Type) -> KeyedEncodingContainer<Key> {
         // If an existing keyed container was already requested, return that one.
         let topContainer: SharedBox<KeyedBox>
         if canEncodeNewValue {
@@ -89,7 +89,7 @@ class XMLEncoderImplementation: Encoder {
         return KeyedEncodingContainer(container)
     }
     
-    open func singleElementContainer<Key>(keyedBy _: Key.Type) -> KeyedEncodingContainer<Key> {
+    public func singleElementContainer<Key>(keyedBy _: Key.Type) -> KeyedEncodingContainer<Key> {
         let topContainer: SharedBox<SingleElementBox>
         if canEncodeNewValue {
             // We haven't yet pushed a container at this level; do so here.

--- a/Sources/XMLCoder/Encoder/XMLEncoderImplementation.swift
+++ b/Sources/XMLCoder/Encoder/XMLEncoderImplementation.swift
@@ -80,6 +80,23 @@ class XMLEncoderImplementation: Encoder {
         let container = XMLKeyedEncodingContainer<Key>(referencing: self, codingPath: codingPath, wrapping: topContainer)
         return KeyedEncodingContainer(container)
     }
+    
+    public func container<Key: XMLChoiceKey>(keyedBy _: Key.Type) -> KeyedEncodingContainer<Key> {
+        let topContainer: SharedBox<SingleElementBox>
+        if canEncodeNewValue {
+            // We haven't yet pushed a container at this level; do so here.
+            topContainer = storage.pushSingleElementContainer()
+        } else {
+            guard let container = storage.lastContainer as? SharedBox<SingleElementBox> else {
+                preconditionFailure("Attempt to push new (single element) keyed encoding container when already previously encoded at this path.")
+            }
+            
+            topContainer = container
+        }
+        
+        let container = XMLSingleElementEncodingContainer<Key>(referencing: self, codingPath: codingPath, wrapping: topContainer)
+        return KeyedEncodingContainer(container)
+    }
 
     public func unkeyedContainer() -> UnkeyedEncodingContainer {
         // If an existing unkeyed container was already requested, return that one.

--- a/Sources/XMLCoder/Encoder/XMLEncoderImplementation.swift
+++ b/Sources/XMLCoder/Encoder/XMLEncoderImplementation.swift
@@ -62,8 +62,16 @@ class XMLEncoderImplementation: Encoder {
     }
 
     // MARK: - Encoder Methods
-
+    
     public func container<Key>(keyedBy _: Key.Type) -> KeyedEncodingContainer<Key> {
+        if Key.self is XMLChoiceKey.Type {
+            return singleElementContainer(keyedBy: Key.self)
+        } else {
+            return keyedContainer(keyedBy: Key.self)
+        }
+    }
+    
+    open func keyedContainer<Key>(keyedBy _: Key.Type) -> KeyedEncodingContainer<Key> {
         // If an existing keyed container was already requested, return that one.
         let topContainer: SharedBox<KeyedBox>
         if canEncodeNewValue {
@@ -81,7 +89,7 @@ class XMLEncoderImplementation: Encoder {
         return KeyedEncodingContainer(container)
     }
     
-    public func container<Key: XMLChoiceKey>(keyedBy _: Key.Type) -> KeyedEncodingContainer<Key> {
+    open func singleElementContainer<Key>(keyedBy _: Key.Type) -> KeyedEncodingContainer<Key> {
         let topContainer: SharedBox<SingleElementBox>
         if canEncodeNewValue {
             // We haven't yet pushed a container at this level; do so here.

--- a/Sources/XMLCoder/Encoder/XMLEncodingStorage.swift
+++ b/Sources/XMLCoder/Encoder/XMLEncodingStorage.swift
@@ -38,7 +38,7 @@ struct XMLEncodingStorage {
     }
     
     mutating func pushSingleElementContainer() -> SharedBox<SingleElementBox> {
-        let container = SharedBox(SingleElementBox(attributes: SingleElementBox.Attributes(), key: "", element: NullBox()))
+        let container = SharedBox(SingleElementBox())
         containers.append(container)
         return container
     }

--- a/Sources/XMLCoder/Encoder/XMLEncodingStorage.swift
+++ b/Sources/XMLCoder/Encoder/XMLEncodingStorage.swift
@@ -36,6 +36,12 @@ struct XMLEncodingStorage {
         containers.append(container)
         return container
     }
+    
+    mutating func pushSingleElementContainer() -> SharedBox<SingleElementBox> {
+        let container = SharedBox(SingleElementBox(attributes: SingleElementBox.Attributes(), key: "", element: NullBox()))
+        containers.append(container)
+        return container
+    }
 
     mutating func pushUnkeyedContainer() -> SharedBox<UnkeyedBox> {
         let container = SharedBox(UnkeyedBox())

--- a/Sources/XMLCoder/Encoder/XMLKeyedEncodingContainer.swift
+++ b/Sources/XMLCoder/Encoder/XMLKeyedEncodingContainer.swift
@@ -174,7 +174,7 @@ struct XMLKeyedEncodingContainer<K: CodingKey>: KeyedEncodingContainerProtocol {
         keyedBy _: NestedKey.Type,
         forKey key: Key
         ) -> KeyedEncodingContainer<NestedKey> {
-        let sharedSingleElement = SharedBox(SingleElementBox(attributes: SingleElementBox.Attributes(), key: "", element: NullBox()))
+        let sharedSingleElement = SharedBox(SingleElementBox())
         
         self.container.withShared { container in
             container.elements.append(sharedSingleElement, at: _converted(key).stringValue)

--- a/Sources/XMLCoder/Encoder/XMLKeyedEncodingContainer.swift
+++ b/Sources/XMLCoder/Encoder/XMLKeyedEncodingContainer.swift
@@ -158,6 +158,48 @@ struct XMLKeyedEncodingContainer<K: CodingKey>: KeyedEncodingContainerProtocol {
         )
         return KeyedEncodingContainer(container)
     }
+    
+    mutating func nestedKeyedContainer<NestedKey>(
+        keyedBy _: NestedKey.Type,
+        forKey key: Key
+    ) -> KeyedEncodingContainer<NestedKey> {
+        let sharedKeyed = SharedBox(KeyedBox())
+        
+        self.container.withShared { container in
+            container.elements.append(sharedKeyed, at: _converted(key).stringValue)
+        }
+        
+        codingPath.append(key)
+        defer { self.codingPath.removeLast() }
+        
+        let container = XMLKeyedEncodingContainer<NestedKey>(
+            referencing: encoder,
+            codingPath: codingPath,
+            wrapping: sharedKeyed
+        )
+        return KeyedEncodingContainer(container)
+    }
+    
+    mutating func nestedSingleElementContainer<NestedKey>(
+        keyedBy _: NestedKey.Type,
+        forKey key: Key
+        ) -> KeyedEncodingContainer<NestedKey> {
+        let sharedSingleElement = SharedBox(SingleElementBox(attributes: SingleElementBox.Attributes(), key: "", element: NullBox()))
+        
+        self.container.withShared { container in
+            container.elements.append(sharedSingleElement, at: _converted(key).stringValue)
+        }
+        
+        codingPath.append(key)
+        defer { self.codingPath.removeLast() }
+        
+        let container = XMLSingleElementEncodingContainer<NestedKey>(
+            referencing: encoder,
+            codingPath: codingPath,
+            wrapping: sharedSingleElement
+        )
+        return KeyedEncodingContainer(container)
+    }
 
     public mutating func nestedUnkeyedContainer(
         forKey key: Key

--- a/Sources/XMLCoder/Encoder/XMLKeyedEncodingContainer.swift
+++ b/Sources/XMLCoder/Encoder/XMLKeyedEncodingContainer.swift
@@ -142,21 +142,11 @@ struct XMLKeyedEncodingContainer<K: CodingKey>: KeyedEncodingContainerProtocol {
         keyedBy _: NestedKey.Type,
         forKey key: Key
     ) -> KeyedEncodingContainer<NestedKey> {
-        let sharedKeyed = SharedBox(KeyedBox())
-
-        self.container.withShared { container in
-            container.elements.append(sharedKeyed, at: _converted(key).stringValue)
+        if NestedKey.self is XMLChoiceKey.Type {
+            return nestedSingleElementContainer(keyedBy: NestedKey.self, forKey: key)
+        } else {
+            return nestedKeyedContainer(keyedBy: NestedKey.self, forKey: key)
         }
-
-        codingPath.append(key)
-        defer { self.codingPath.removeLast() }
-
-        let container = XMLKeyedEncodingContainer<NestedKey>(
-            referencing: encoder,
-            codingPath: codingPath,
-            wrapping: sharedKeyed
-        )
-        return KeyedEncodingContainer(container)
     }
     
     mutating func nestedKeyedContainer<NestedKey>(

--- a/Sources/XMLCoder/Encoder/XMLReferencingEncoder.swift
+++ b/Sources/XMLCoder/Encoder/XMLReferencingEncoder.swift
@@ -24,6 +24,9 @@ class XMLReferencingEncoder: XMLEncoderImplementation {
 
         /// Referencing a specific key in a keyed container.
         case keyed(SharedBox<KeyedBox>, String)
+        
+        /// Referencing a specific key in a keyed container.
+        case singleElement(SharedBox<SingleElementBox>, String)
     }
 
     // MARK: - Properties
@@ -70,6 +73,23 @@ class XMLReferencingEncoder: XMLEncoderImplementation {
 
         codingPath.append(key)
     }
+    
+    init(
+        referencing encoder: XMLEncoderImplementation,
+        key: CodingKey,
+        convertedKey: CodingKey,
+        wrapping sharedKeyed: SharedBox<SingleElementBox>
+        ) {
+        self.encoder = encoder
+        reference = .singleElement(sharedKeyed, convertedKey.stringValue)
+        super.init(
+            options: encoder.options,
+            nodeEncodings: encoder.nodeEncodings,
+            codingPath: encoder.codingPath
+        )
+        
+        codingPath.append(key)
+    }
 
     // MARK: - Coding Path Operations
 
@@ -99,6 +119,11 @@ class XMLReferencingEncoder: XMLEncoderImplementation {
         case let .keyed(sharedKeyedBox, key):
             sharedKeyedBox.withShared { keyedBox in
                 keyedBox.elements.append(box, at: key)
+            }
+        case let .singleElement(sharedSingleElementBox, key):
+            sharedSingleElementBox.withShared { singleElementBox in
+                singleElementBox.element = box
+                singleElementBox.key = key
             }
         }
     }

--- a/Sources/XMLCoder/Encoder/XMLSingleElementEncodingContainer.swift
+++ b/Sources/XMLCoder/Encoder/XMLSingleElementEncodingContainer.swift
@@ -177,7 +177,7 @@ struct XMLSingleElementEncodingContainer<K: CodingKey>: KeyedEncodingContainerPr
         keyedBy _: NestedKey.Type,
         forKey key: Key
         ) -> KeyedEncodingContainer<NestedKey> {
-        let sharedSingleElement = SharedBox(SingleElementBox(attributes: SingleElementBox.Attributes(), key: "", element: NullBox()))
+        let sharedSingleElement = SharedBox(SingleElementBox())
         
         self.container.withShared { container in
             container.element = sharedSingleElement

--- a/Sources/XMLCoder/Encoder/XMLSingleElementEncodingContainer.swift
+++ b/Sources/XMLCoder/Encoder/XMLSingleElementEncodingContainer.swift
@@ -16,7 +16,7 @@ struct XMLSingleElementEncodingContainer<K: XMLChoiceKey>: KeyedEncodingContaine
     private let encoder: XMLEncoderImplementation
     
     /// A reference to the container we're writing to.
-    private var container: SharedBox<KeyedBox>
+    private var container: SharedBox<SingleElementBox>
     
     /// The path of coding keys taken to get to this point in encoding.
     public private(set) var codingPath: [CodingKey]
@@ -27,7 +27,7 @@ struct XMLSingleElementEncodingContainer<K: XMLChoiceKey>: KeyedEncodingContaine
     init(
         referencing encoder: XMLEncoderImplementation,
         codingPath: [CodingKey],
-        wrapping container: SharedBox<KeyedBox>
+        wrapping container: SharedBox<SingleElementBox>
         ) {
         self.encoder = encoder
         self.codingPath = codingPath
@@ -69,7 +69,8 @@ struct XMLSingleElementEncodingContainer<K: XMLChoiceKey>: KeyedEncodingContaine
     
     public mutating func encodeNil(forKey key: Key) throws {
         container.withShared {
-            $0.elements.append(NullBox(), at: _converted(key).stringValue)
+            $0.key = _converted(key).stringValue
+            $0.element = NullBox()
         }
     }
     
@@ -119,7 +120,8 @@ struct XMLSingleElementEncodingContainer<K: XMLChoiceKey>: KeyedEncodingContaine
         
         let elementEncoder: (T, Key, Box) throws -> () = { _, key, box in
             mySelf.container.withShared { container in
-                container.elements.append(box, at: mySelf._converted(key).stringValue)
+                container.element = box
+                container.key = mySelf._converted(key).stringValue
             }
         }
         
@@ -145,7 +147,8 @@ struct XMLSingleElementEncodingContainer<K: XMLChoiceKey>: KeyedEncodingContaine
         let sharedKeyed = SharedBox(KeyedBox())
         
         self.container.withShared { container in
-            container.elements.append(sharedKeyed, at: _converted(key).stringValue)
+            container.element = sharedKeyed
+            container.key = _converted(key).stringValue
         }
         
         codingPath.append(key)
@@ -165,7 +168,8 @@ struct XMLSingleElementEncodingContainer<K: XMLChoiceKey>: KeyedEncodingContaine
         let sharedUnkeyed = SharedBox(UnkeyedBox())
         
         container.withShared { container in
-            container.elements.append(sharedUnkeyed, at: _converted(key).stringValue)
+            container.element = sharedUnkeyed
+            container.key = _converted(key).stringValue
         }
         
         codingPath.append(key)

--- a/Sources/XMLCoder/Encoder/XMLSingleElementEncodingContainer.swift
+++ b/Sources/XMLCoder/Encoder/XMLSingleElementEncodingContainer.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-struct XMLKeyedEncodingContainer<K: CodingKey>: KeyedEncodingContainerProtocol {
+struct XMLSingleElementEncodingContainer<K: XMLChoiceKey>: KeyedEncodingContainerProtocol {
     typealias Key = K
     
     // MARK: Properties
@@ -176,22 +176,22 @@ struct XMLKeyedEncodingContainer<K: CodingKey>: KeyedEncodingContainerProtocol {
             wrapping: sharedUnkeyed
         )
     }
-//
-//    public mutating func superEncoder() -> Encoder {
-//        return XMLReferencingEncoder(
-//            referencing: encoder,
-//            key: XMLKey.super,
-//            convertedKey: _converted(XMLKey.super),
-//            wrapping: container
-//        )
-//    }
-//
-//    public mutating func superEncoder(forKey key: Key) -> Encoder {
-//        return XMLReferencingEncoder(
-//            referencing: encoder,
-//            key: key,
-//            convertedKey: _converted(key),
-//            wrapping: container
-//        )
-//    }
+
+    public mutating func superEncoder() -> Encoder {
+        return XMLReferencingEncoder(
+            referencing: encoder,
+            key: XMLKey.super,
+            convertedKey: _converted(XMLKey.super),
+            wrapping: container
+        )
+    }
+
+    public mutating func superEncoder(forKey key: Key) -> Encoder {
+        return XMLReferencingEncoder(
+            referencing: encoder,
+            key: key,
+            convertedKey: _converted(key),
+            wrapping: container
+        )
+    }
 }

--- a/Sources/XMLCoder/Encoder/XMLSingleElementEncodingContainer.swift
+++ b/Sources/XMLCoder/Encoder/XMLSingleElementEncodingContainer.swift
@@ -1,0 +1,197 @@
+//
+//  XMLSingleElementEncodingContainer.swift
+//  XMLCoder
+//
+//  Created by Benjamin Wetherfield on 7/17/19.
+//
+
+import Foundation
+
+struct XMLKeyedEncodingContainer<K: CodingKey>: KeyedEncodingContainerProtocol {
+    typealias Key = K
+    
+    // MARK: Properties
+    
+    /// A reference to the encoder we're writing to.
+    private let encoder: XMLEncoderImplementation
+    
+    /// A reference to the container we're writing to.
+    private var container: SharedBox<KeyedBox>
+    
+    /// The path of coding keys taken to get to this point in encoding.
+    public private(set) var codingPath: [CodingKey]
+    
+    // MARK: - Initialization
+    
+    /// Initializes `self` with the given references.
+    init(
+        referencing encoder: XMLEncoderImplementation,
+        codingPath: [CodingKey],
+        wrapping container: SharedBox<KeyedBox>
+        ) {
+        self.encoder = encoder
+        self.codingPath = codingPath
+        self.container = container
+    }
+    
+    // MARK: - Coding Path Operations
+    
+    private func _converted(_ key: CodingKey) -> CodingKey {
+        switch encoder.options.keyEncodingStrategy {
+        case .useDefaultKeys:
+            return key
+        case .convertToSnakeCase:
+            let newKeyString = XMLEncoder.KeyEncodingStrategy
+                ._convertToSnakeCase(key.stringValue)
+            return XMLKey(stringValue: newKeyString, intValue: key.intValue)
+        case .convertToKebabCase:
+            let newKeyString = XMLEncoder.KeyEncodingStrategy
+                ._convertToKebabCase(key.stringValue)
+            return XMLKey(stringValue: newKeyString, intValue: key.intValue)
+        case let .custom(converter):
+            return converter(codingPath + [key])
+        case .capitalized:
+            let newKeyString = XMLEncoder.KeyEncodingStrategy
+                ._convertToCapitalized(key.stringValue)
+            return XMLKey(stringValue: newKeyString, intValue: key.intValue)
+        case .uppercased:
+            let newKeyString = XMLEncoder.KeyEncodingStrategy
+                ._convertToUppercased(key.stringValue)
+            return XMLKey(stringValue: newKeyString, intValue: key.intValue)
+        case .lowercased:
+            let newKeyString = XMLEncoder.KeyEncodingStrategy
+                ._convertToLowercased(key.stringValue)
+            return XMLKey(stringValue: newKeyString, intValue: key.intValue)
+        }
+    }
+    
+    // MARK: - KeyedEncodingContainerProtocol Methods
+    
+    public mutating func encodeNil(forKey key: Key) throws {
+        container.withShared {
+            $0.elements.append(NullBox(), at: _converted(key).stringValue)
+        }
+    }
+    
+    public mutating func encode<T: Encodable>(
+        _ value: T,
+        forKey key: Key
+        ) throws {
+        return try encode(value, forKey: key) { encoder, value in
+            try encoder.box(value)
+        }
+    }
+    
+    private mutating func encode<T: Encodable>(
+        _ value: T,
+        forKey key: Key,
+        encode: (XMLEncoderImplementation, T) throws -> Box
+        ) throws {
+        defer {
+            _ = self.encoder.nodeEncodings.removeLast()
+            self.encoder.codingPath.removeLast()
+        }
+        guard let strategy = self.encoder.nodeEncodings.last else {
+            preconditionFailure(
+                "Attempt to access node encoding strategy from empty stack."
+            )
+        }
+        encoder.codingPath.append(key)
+        let nodeEncodings = encoder.options.nodeEncodingStrategy.nodeEncodings(
+            forType: T.self,
+            with: encoder
+        )
+        encoder.nodeEncodings.append(nodeEncodings)
+        let box = try encode(encoder, value)
+        
+        let mySelf = self
+        let attributeEncoder: (T, Key, Box) throws -> () = { value, key, box in
+            guard let attribute = box as? SimpleBox else {
+                throw EncodingError.invalidValue(value, EncodingError.Context(
+                    codingPath: [],
+                    debugDescription: "Complex values cannot be encoded as attributes."
+                ))
+            }
+            mySelf.container.withShared { container in
+                container.attributes.append(attribute, at: mySelf._converted(key).stringValue)
+            }
+        }
+        
+        let elementEncoder: (T, Key, Box) throws -> () = { _, key, box in
+            mySelf.container.withShared { container in
+                container.elements.append(box, at: mySelf._converted(key).stringValue)
+            }
+        }
+        
+        defer {
+            self = mySelf
+        }
+        
+        switch strategy(key) {
+        case .attribute:
+            try attributeEncoder(value, key, box)
+        case .element:
+            try elementEncoder(value, key, box)
+        case .both:
+            try attributeEncoder(value, key, box)
+            try elementEncoder(value, key, box)
+        }
+    }
+    
+    public mutating func nestedContainer<NestedKey>(
+        keyedBy _: NestedKey.Type,
+        forKey key: Key
+        ) -> KeyedEncodingContainer<NestedKey> {
+        let sharedKeyed = SharedBox(KeyedBox())
+        
+        self.container.withShared { container in
+            container.elements.append(sharedKeyed, at: _converted(key).stringValue)
+        }
+        
+        codingPath.append(key)
+        defer { self.codingPath.removeLast() }
+        
+        let container = XMLKeyedEncodingContainer<NestedKey>(
+            referencing: encoder,
+            codingPath: codingPath,
+            wrapping: sharedKeyed
+        )
+        return KeyedEncodingContainer(container)
+    }
+    
+    public mutating func nestedUnkeyedContainer(
+        forKey key: Key
+        ) -> UnkeyedEncodingContainer {
+        let sharedUnkeyed = SharedBox(UnkeyedBox())
+        
+        container.withShared { container in
+            container.elements.append(sharedUnkeyed, at: _converted(key).stringValue)
+        }
+        
+        codingPath.append(key)
+        defer { self.codingPath.removeLast() }
+        return XMLUnkeyedEncodingContainer(
+            referencing: encoder,
+            codingPath: codingPath,
+            wrapping: sharedUnkeyed
+        )
+    }
+//
+//    public mutating func superEncoder() -> Encoder {
+//        return XMLReferencingEncoder(
+//            referencing: encoder,
+//            key: XMLKey.super,
+//            convertedKey: _converted(XMLKey.super),
+//            wrapping: container
+//        )
+//    }
+//
+//    public mutating func superEncoder(forKey key: Key) -> Encoder {
+//        return XMLReferencingEncoder(
+//            referencing: encoder,
+//            key: key,
+//            convertedKey: _converted(key),
+//            wrapping: container
+//        )
+//    }
+}

--- a/Sources/XMLCoder/Encoder/XMLSingleElementEncodingContainer.swift
+++ b/Sources/XMLCoder/Encoder/XMLSingleElementEncodingContainer.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-struct XMLSingleElementEncodingContainer<K: XMLChoiceKey>: KeyedEncodingContainerProtocol {
+struct XMLSingleElementEncodingContainer<K: CodingKey>: KeyedEncodingContainerProtocol {
     typealias Key = K
     
     // MARK: Properties

--- a/Sources/XMLCoder/Encoder/XMLUnkeyedEncodingContainer.swift
+++ b/Sources/XMLCoder/Encoder/XMLUnkeyedEncodingContainer.swift
@@ -94,7 +94,7 @@ struct XMLUnkeyedEncodingContainer: UnkeyedEncodingContainer {
         codingPath.append(XMLKey(index: count))
         defer { self.codingPath.removeLast() }
         
-        let sharedSingleElement = SharedBox(SingleElementBox(attributes: SingleElementBox.Attributes(), key: "", element: NullBox()))
+        let sharedSingleElement = SharedBox(SingleElementBox())
         self.container.withShared { container in
             container.append(sharedSingleElement)
         }

--- a/Sources/XMLCoder/Encoder/XMLUnkeyedEncodingContainer.swift
+++ b/Sources/XMLCoder/Encoder/XMLUnkeyedEncodingContainer.swift
@@ -62,22 +62,47 @@ struct XMLUnkeyedEncodingContainer: UnkeyedEncodingContainer {
             container.append(try encode(encoder, value))
         }
     }
-
+    
     public mutating func nestedContainer<NestedKey>(
         keyedBy _: NestedKey.Type
-    ) -> KeyedEncodingContainer<NestedKey> {
+        ) -> KeyedEncodingContainer<NestedKey> {
+        if NestedKey.self is XMLChoiceKey.Type {
+            return nestedSingleElementContainer(keyedBy: NestedKey.self)
+        } else {
+            return nestedKeyedContainer(keyedBy: NestedKey.self)
+        }
+    }
+    
+    public mutating func nestedKeyedContainer<NestedKey>(keyedBy _: NestedKey.Type) -> KeyedEncodingContainer<NestedKey> {
         codingPath.append(XMLKey(index: count))
         defer { self.codingPath.removeLast() }
-
+        
         let sharedKeyed = SharedBox(KeyedBox())
         self.container.withShared { container in
             container.append(sharedKeyed)
         }
-
+        
         let container = XMLKeyedEncodingContainer<NestedKey>(
             referencing: encoder,
             codingPath: codingPath,
             wrapping: sharedKeyed
+        )
+        return KeyedEncodingContainer(container)
+    }
+    
+    public mutating func nestedSingleElementContainer<NestedKey>(keyedBy _: NestedKey.Type) -> KeyedEncodingContainer<NestedKey> {
+        codingPath.append(XMLKey(index: count))
+        defer { self.codingPath.removeLast() }
+        
+        let sharedSingleElement = SharedBox(SingleElementBox(attributes: SingleElementBox.Attributes(), key: "", element: NullBox()))
+        self.container.withShared { container in
+            container.append(sharedSingleElement)
+        }
+        
+        let container = XMLSingleElementEncodingContainer<NestedKey>(
+            referencing: encoder,
+            codingPath: codingPath,
+            wrapping: sharedSingleElement
         )
         return KeyedEncodingContainer(container)
     }

--- a/Tests/XMLCoderTests/SimpleChoiceTests.swift
+++ b/Tests/XMLCoderTests/SimpleChoiceTests.swift
@@ -14,7 +14,7 @@ private enum IntOrString: Equatable {
 }
 
 extension IntOrString: XMLChoiceCodable {
-    enum CodingKeys: String, CodingKey {
+    enum CodingKeys: String, XMLChoiceKey {
         case int
         case string
     }

--- a/XMLCoder.xcodeproj/project.pbxproj
+++ b/XMLCoder.xcodeproj/project.pbxproj
@@ -40,6 +40,7 @@
 		B3BE1D682202CBF800259831 /* XMLDecoderImplementation.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3BE1D662202CBF800259831 /* XMLDecoderImplementation.swift */; };
 		B3BE1D692202CBF800259831 /* SingleValueDecodingContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3BE1D672202CBF800259831 /* SingleValueDecodingContainer.swift */; };
 		B54B122E22DF916F0014109D /* XMLChoiceKey.swift in Sources */ = {isa = PBXBuildFile; fileRef = B54B122D22DF916F0014109D /* XMLChoiceKey.swift */; };
+		B54B123022DF921B0014109D /* XMLSingleElementEncodingContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = B54B122F22DF921B0014109D /* XMLSingleElementEncodingContainer.swift */; };
 		BF63EF0021CCDED2001D38C5 /* XMLStackParserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF63EEFF21CCDED2001D38C5 /* XMLStackParserTests.swift */; };
 		BF63EF0621CD7A74001D38C5 /* URLBox.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF63EF0521CD7A74001D38C5 /* URLBox.swift */; };
 		BF63EF0821CD7AF8001D38C5 /* URLBoxTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF63EF0721CD7AF8001D38C5 /* URLBoxTests.swift */; };
@@ -170,6 +171,7 @@
 		B3BE1D662202CBF800259831 /* XMLDecoderImplementation.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = XMLDecoderImplementation.swift; sourceTree = "<group>"; };
 		B3BE1D672202CBF800259831 /* SingleValueDecodingContainer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SingleValueDecodingContainer.swift; sourceTree = "<group>"; };
 		B54B122D22DF916F0014109D /* XMLChoiceKey.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XMLChoiceKey.swift; sourceTree = "<group>"; };
+		B54B122F22DF921B0014109D /* XMLSingleElementEncodingContainer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XMLSingleElementEncodingContainer.swift; sourceTree = "<group>"; };
 		BF63EEFF21CCDED2001D38C5 /* XMLStackParserTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XMLStackParserTests.swift; sourceTree = "<group>"; };
 		BF63EF0521CD7A74001D38C5 /* URLBox.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLBox.swift; sourceTree = "<group>"; };
 		BF63EF0721CD7AF8001D38C5 /* URLBoxTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLBoxTests.swift; sourceTree = "<group>"; };
@@ -393,6 +395,7 @@
 				B3BE1D622202CB1400259831 /* XMLEncoderImplementation.swift */,
 				OBJ_18 /* XMLEncodingStorage.swift */,
 				OBJ_19 /* XMLKeyedEncodingContainer.swift */,
+				B54B122F22DF921B0014109D /* XMLSingleElementEncodingContainer.swift */,
 				OBJ_20 /* XMLReferencingEncoder.swift */,
 				OBJ_21 /* XMLUnkeyedEncodingContainer.swift */,
 				1482D59D22DD2A6B00AE2D6E /* XMLChoiceEncodable.swift */,
@@ -651,6 +654,7 @@
 				BF9457A921CBB498005ACFDE /* KeyedBox.swift in Sources */,
 				BF9457D721CBB59E005ACFDE /* IntBox.swift in Sources */,
 				BF9457AD21CBB498005ACFDE /* BoolBox.swift in Sources */,
+				B54B123022DF921B0014109D /* XMLSingleElementEncodingContainer.swift in Sources */,
 				BF9457B821CBB4DB005ACFDE /* String+Extensions.swift in Sources */,
 				BF9457AE21CBB498005ACFDE /* Box.swift in Sources */,
 				BF9457DA21CBB5D2005ACFDE /* DataBox.swift in Sources */,

--- a/XMLCoder.xcodeproj/project.pbxproj
+++ b/XMLCoder.xcodeproj/project.pbxproj
@@ -39,6 +39,7 @@
 		B3BE1D652202CB7200259831 /* SingleValueEncodingContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3BE1D642202CB7200259831 /* SingleValueEncodingContainer.swift */; };
 		B3BE1D682202CBF800259831 /* XMLDecoderImplementation.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3BE1D662202CBF800259831 /* XMLDecoderImplementation.swift */; };
 		B3BE1D692202CBF800259831 /* SingleValueDecodingContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3BE1D672202CBF800259831 /* SingleValueDecodingContainer.swift */; };
+		B54B122E22DF916F0014109D /* XMLChoiceKey.swift in Sources */ = {isa = PBXBuildFile; fileRef = B54B122D22DF916F0014109D /* XMLChoiceKey.swift */; };
 		BF63EF0021CCDED2001D38C5 /* XMLStackParserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF63EEFF21CCDED2001D38C5 /* XMLStackParserTests.swift */; };
 		BF63EF0621CD7A74001D38C5 /* URLBox.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF63EF0521CD7A74001D38C5 /* URLBox.swift */; };
 		BF63EF0821CD7AF8001D38C5 /* URLBoxTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF63EF0721CD7AF8001D38C5 /* URLBoxTests.swift */; };
@@ -168,6 +169,7 @@
 		B3BE1D642202CB7200259831 /* SingleValueEncodingContainer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SingleValueEncodingContainer.swift; sourceTree = "<group>"; };
 		B3BE1D662202CBF800259831 /* XMLDecoderImplementation.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = XMLDecoderImplementation.swift; sourceTree = "<group>"; };
 		B3BE1D672202CBF800259831 /* SingleValueDecodingContainer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SingleValueDecodingContainer.swift; sourceTree = "<group>"; };
+		B54B122D22DF916F0014109D /* XMLChoiceKey.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XMLChoiceKey.swift; sourceTree = "<group>"; };
 		BF63EEFF21CCDED2001D38C5 /* XMLStackParserTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XMLStackParserTests.swift; sourceTree = "<group>"; };
 		BF63EF0521CD7A74001D38C5 /* URLBox.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLBox.swift; sourceTree = "<group>"; };
 		BF63EF0721CD7AF8001D38C5 /* URLBoxTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLBoxTests.swift; sourceTree = "<group>"; };
@@ -332,6 +334,7 @@
 				BF9457B321CBB4DB005ACFDE /* XMLStackParser.swift */,
 				BF9457B521CBB4DB005ACFDE /* XMLKey.swift */,
 				1482D59922DD2A1700AE2D6E /* XMLChoiceCodable.swift */,
+				B54B122D22DF916F0014109D /* XMLChoiceKey.swift */,
 			);
 			path = Auxiliaries;
 			sourceTree = "<group>";
@@ -636,6 +639,7 @@
 				1482D59A22DD2A1700AE2D6E /* XMLChoiceCodable.swift in Sources */,
 				OBJ_51 /* XMLKeyedDecodingContainer.swift in Sources */,
 				OBJ_52 /* XMLUnkeyedDecodingContainer.swift in Sources */,
+				B54B122E22DF916F0014109D /* XMLChoiceKey.swift in Sources */,
 				OBJ_53 /* EncodingErrorExtension.swift in Sources */,
 				1482D59C22DD2A4400AE2D6E /* XMLChoiceDecodable.swift in Sources */,
 				1482D59E22DD2A6B00AE2D6E /* XMLChoiceEncodable.swift in Sources */,


### PR DESCRIPTION
Adds a `KeyedEncodingContainer`-conforming type `XMLSingleElementEncodingContainer`, which is a `SingleElementBox` analog to `XMLKeyedEncodingContainer` (`KeyedBox`-based). `XMLChoiceKey: CodingKey` provides an opt-in switch on the user side to make use of `XMLSingleElementEncodingContainer`, which provides fixes for the encoding of enum-with-associated-value (or, in XML, choice types) so far just on the encoding side.