### PR TITLE
Remove XMLChoiceCodable

### DIFF
--- a/Sources/XMLCoder/Auxiliaries/XMLChoiceCodable.swift
+++ b/Sources/XMLCoder/Auxiliaries/XMLChoiceCodable.swift
@@ -1,8 +1,0 @@
-//
-//  XMLChoiceCodable.swift
-//  XMLCoder
-//
-//  Created by James Bean on 7/15/19.
-//
-
-public protocol XMLChoiceCodable: XMLChoiceEncodable, XMLChoiceDecodable {}

--- a/Sources/XMLCoder/Decoder/XMLChoiceDecodable.swift
+++ b/Sources/XMLCoder/Decoder/XMLChoiceDecodable.swift
@@ -1,8 +1,0 @@
-//
-//  XMLChoiceDecodable.swift
-//  XMLCoder
-//
-//  Created by James Bean on 7/15/19.
-//
-
-public protocol XMLChoiceDecodable: Decodable {}

--- a/Sources/XMLCoder/Encoder/XMLChoiceEncodable.swift
+++ b/Sources/XMLCoder/Encoder/XMLChoiceEncodable.swift
@@ -1,8 +1,0 @@
-//
-//  XMLChoiceEncodable.swift
-//  XMLCoder
-//
-//  Created by James Bean on 7/15/19.
-//
-
-public protocol XMLChoiceEncodable: Encodable {}

--- a/Tests/XMLCoderTests/CompositeChoiceTests.swift
+++ b/Tests/XMLCoderTests/CompositeChoiceTests.swift
@@ -21,7 +21,7 @@ private enum IntOrStringWrapper: Equatable {
     case string(StringWrapper)
 }
 
-extension IntOrStringWrapper: XMLChoiceCodable {
+extension IntOrStringWrapper: Codable {
     enum CodingKeys: String, CodingKey {
         case int
         case string

--- a/Tests/XMLCoderTests/NestedChoiceTests.swift
+++ b/Tests/XMLCoderTests/NestedChoiceTests.swift
@@ -52,7 +52,7 @@ extension Paragraph: Codable {
     }
 }
 
-extension Entry: XMLChoiceCodable {
+extension Entry: Codable {
     private enum CodingKeys: String, CodingKey {
         case run, properties, br
     }

--- a/Tests/XMLCoderTests/SimpleChoiceTests.swift
+++ b/Tests/XMLCoderTests/SimpleChoiceTests.swift
@@ -13,7 +13,7 @@ private enum IntOrString: Equatable {
     case string(String)
 }
 
-extension IntOrString: XMLChoiceCodable {
+extension IntOrString: Codable {
     enum CodingKeys: String, XMLChoiceKey {
         case int
         case string

--- a/XMLCoder.xcodeproj/project.pbxproj
+++ b/XMLCoder.xcodeproj/project.pbxproj
@@ -21,7 +21,6 @@
 /* End PBXAggregateTarget section */
 
 /* Begin PBXBuildFile section */
-		1482D59A22DD2A1700AE2D6E /* XMLChoiceCodable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1482D59922DD2A1700AE2D6E /* XMLChoiceCodable.swift */; };
 		1482D59C22DD2A4400AE2D6E /* XMLChoiceDecodable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1482D59B22DD2A4400AE2D6E /* XMLChoiceDecodable.swift */; };
 		1482D59E22DD2A6B00AE2D6E /* XMLChoiceEncodable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1482D59D22DD2A6B00AE2D6E /* XMLChoiceEncodable.swift */; };
 		1482D5A222DD2D9400AE2D6E /* SimpleChoiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1482D5A122DD2D9400AE2D6E /* SimpleChoiceTests.swift */; };
@@ -152,7 +151,6 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
-		1482D59922DD2A1700AE2D6E /* XMLChoiceCodable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XMLChoiceCodable.swift; sourceTree = "<group>"; };
 		1482D59B22DD2A4400AE2D6E /* XMLChoiceDecodable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XMLChoiceDecodable.swift; sourceTree = "<group>"; };
 		1482D59D22DD2A6B00AE2D6E /* XMLChoiceEncodable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XMLChoiceEncodable.swift; sourceTree = "<group>"; };
 		1482D5A122DD2D9400AE2D6E /* SimpleChoiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SimpleChoiceTests.swift; sourceTree = "<group>"; };
@@ -335,7 +333,6 @@
 				BF9457B121CBB4DB005ACFDE /* XMLHeader.swift */,
 				BF9457B321CBB4DB005ACFDE /* XMLStackParser.swift */,
 				BF9457B521CBB4DB005ACFDE /* XMLKey.swift */,
-				1482D59922DD2A1700AE2D6E /* XMLChoiceCodable.swift */,
 				B54B122D22DF916F0014109D /* XMLChoiceKey.swift */,
 			);
 			path = Auxiliaries;
@@ -639,7 +636,6 @@
 				B3BE1D652202CB7200259831 /* SingleValueEncodingContainer.swift in Sources */,
 				BF9457D521CBB59E005ACFDE /* UIntBox.swift in Sources */,
 				D1EC3E65225A38EC00C610E3 /* KeyedStorage.swift in Sources */,
-				1482D59A22DD2A1700AE2D6E /* XMLChoiceCodable.swift in Sources */,
 				OBJ_51 /* XMLKeyedDecodingContainer.swift in Sources */,
 				OBJ_52 /* XMLUnkeyedDecodingContainer.swift in Sources */,
 				B54B122E22DF916F0014109D /* XMLChoiceKey.swift in Sources */,

--- a/XMLCoder.xcodeproj/project.pbxproj
+++ b/XMLCoder.xcodeproj/project.pbxproj
@@ -21,7 +21,6 @@
 /* End PBXAggregateTarget section */
 
 /* Begin PBXBuildFile section */
-		1482D59E22DD2A6B00AE2D6E /* XMLChoiceEncodable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1482D59D22DD2A6B00AE2D6E /* XMLChoiceEncodable.swift */; };
 		1482D5A222DD2D9400AE2D6E /* SimpleChoiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1482D5A122DD2D9400AE2D6E /* SimpleChoiceTests.swift */; };
 		1482D5A422DD2F4D00AE2D6E /* CompositeChoiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1482D5A322DD2F4D00AE2D6E /* CompositeChoiceTests.swift */; };
 		1482D5A822DD6AEE00AE2D6E /* SingleElementBox.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1482D5A722DD6AED00AE2D6E /* SingleElementBox.swift */; };
@@ -150,7 +149,6 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
-		1482D59D22DD2A6B00AE2D6E /* XMLChoiceEncodable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XMLChoiceEncodable.swift; sourceTree = "<group>"; };
 		1482D5A122DD2D9400AE2D6E /* SimpleChoiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SimpleChoiceTests.swift; sourceTree = "<group>"; };
 		1482D5A322DD2F4D00AE2D6E /* CompositeChoiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompositeChoiceTests.swift; sourceTree = "<group>"; };
 		1482D5A722DD6AED00AE2D6E /* SingleElementBox.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SingleElementBox.swift; sourceTree = "<group>"; };
@@ -393,7 +391,6 @@
 				B54B122F22DF921B0014109D /* XMLSingleElementEncodingContainer.swift */,
 				OBJ_20 /* XMLReferencingEncoder.swift */,
 				OBJ_21 /* XMLUnkeyedEncodingContainer.swift */,
-				1482D59D22DD2A6B00AE2D6E /* XMLChoiceEncodable.swift */,
 			);
 			path = Encoder;
 			sourceTree = "<group>";
@@ -637,7 +634,6 @@
 				OBJ_52 /* XMLUnkeyedDecodingContainer.swift in Sources */,
 				B54B122E22DF916F0014109D /* XMLChoiceKey.swift in Sources */,
 				OBJ_53 /* EncodingErrorExtension.swift in Sources */,
-				1482D59E22DD2A6B00AE2D6E /* XMLChoiceEncodable.swift in Sources */,
 				BF9457B921CBB4DB005ACFDE /* XMLStackParser.swift in Sources */,
 				OBJ_54 /* XMLEncoder.swift in Sources */,
 				B35157CE21F986DD009CA0CC /* DynamicNodeEncoding.swift in Sources */,

--- a/XMLCoder.xcodeproj/project.pbxproj
+++ b/XMLCoder.xcodeproj/project.pbxproj
@@ -21,7 +21,6 @@
 /* End PBXAggregateTarget section */
 
 /* Begin PBXBuildFile section */
-		1482D59C22DD2A4400AE2D6E /* XMLChoiceDecodable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1482D59B22DD2A4400AE2D6E /* XMLChoiceDecodable.swift */; };
 		1482D59E22DD2A6B00AE2D6E /* XMLChoiceEncodable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1482D59D22DD2A6B00AE2D6E /* XMLChoiceEncodable.swift */; };
 		1482D5A222DD2D9400AE2D6E /* SimpleChoiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1482D5A122DD2D9400AE2D6E /* SimpleChoiceTests.swift */; };
 		1482D5A422DD2F4D00AE2D6E /* CompositeChoiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1482D5A322DD2F4D00AE2D6E /* CompositeChoiceTests.swift */; };
@@ -151,7 +150,6 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
-		1482D59B22DD2A4400AE2D6E /* XMLChoiceDecodable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XMLChoiceDecodable.swift; sourceTree = "<group>"; };
 		1482D59D22DD2A6B00AE2D6E /* XMLChoiceEncodable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XMLChoiceEncodable.swift; sourceTree = "<group>"; };
 		1482D5A122DD2D9400AE2D6E /* SimpleChoiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SimpleChoiceTests.swift; sourceTree = "<group>"; };
 		1482D5A322DD2F4D00AE2D6E /* CompositeChoiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompositeChoiceTests.swift; sourceTree = "<group>"; };
@@ -503,7 +501,6 @@
 				OBJ_12 /* XMLDecodingStorage.swift */,
 				OBJ_13 /* XMLKeyedDecodingContainer.swift */,
 				OBJ_14 /* XMLUnkeyedDecodingContainer.swift */,
-				1482D59B22DD2A4400AE2D6E /* XMLChoiceDecodable.swift */,
 			);
 			path = Decoder;
 			sourceTree = "<group>";
@@ -640,7 +637,6 @@
 				OBJ_52 /* XMLUnkeyedDecodingContainer.swift in Sources */,
 				B54B122E22DF916F0014109D /* XMLChoiceKey.swift in Sources */,
 				OBJ_53 /* EncodingErrorExtension.swift in Sources */,
-				1482D59C22DD2A4400AE2D6E /* XMLChoiceDecodable.swift in Sources */,
 				1482D59E22DD2A6B00AE2D6E /* XMLChoiceEncodable.swift in Sources */,
 				BF9457B921CBB4DB005ACFDE /* XMLStackParser.swift in Sources */,
 				OBJ_54 /* XMLEncoder.swift in Sources */,


### PR DESCRIPTION
This PR removes all remnants of `XMLChoiceCodable`, `XMLChoiceEncodable`, and `XMLChoiceDecodable`.