### PR TITLE
Fix decoding of null choice elements

### DIFF
--- a/Sources/XMLCoder/Auxiliaries/KeyedStorage.swift
+++ b/Sources/XMLCoder/Auxiliaries/KeyedStorage.swift
@@ -83,7 +83,7 @@ extension KeyedStorage where Key == String, Value == Box {
         } else if let value = element.value {
             result.append(StringBox(value), at: element.key)
         } else {
-            result.append(NullBox(), at: element.key)
+            result.append(ChoiceBox(key: element.key, element: NullBox()), at: element.key)
         }
 
         return result

--- a/Sources/XMLCoder/Auxiliaries/KeyedStorage.swift
+++ b/Sources/XMLCoder/Auxiliaries/KeyedStorage.swift
@@ -83,7 +83,7 @@ extension KeyedStorage where Key == String, Value == Box {
         } else if let value = element.value {
             result.append(StringBox(value), at: element.key)
         } else {
-            result.append(ChoiceBox(key: element.key, element: NullBox()), at: element.key)
+            result.append(SingleElementBox(attributes: .init(), key: element.key, element: NullBox()), at: element.key)
         }
 
         return result

--- a/Sources/XMLCoder/Decoder/XMLDecoderImplementation.swift
+++ b/Sources/XMLCoder/Decoder/XMLDecoderImplementation.swift
@@ -149,6 +149,8 @@ class XMLDecoderImplementation: Decoder {
         switch topContainer {
         case let choice as ChoiceBox:
             choiceBox = choice
+        case let singleElement as SingleElementBox:
+            choiceBox = ChoiceBox(singleElement)
         case let keyed as SharedBox<KeyedBox>:
             choiceBox = ChoiceBox(keyed.withShared { $0 })
         default:

--- a/Sources/XMLCoder/Decoder/XMLDecoderImplementation.swift
+++ b/Sources/XMLCoder/Decoder/XMLDecoderImplementation.swift
@@ -72,10 +72,8 @@ class XMLDecoderImplementation: Decoder {
 
     public func container<Key>(keyedBy keyType: Key.Type) throws -> KeyedDecodingContainer<Key> {
         if Key.self is XMLChoiceKey.Type {
-            print("choice route")
             return try choiceContainer(keyedBy: keyType)
         } else {
-            print("keyed route")
             return try keyedContainer(keyedBy: keyType)
         }
     }
@@ -413,11 +411,9 @@ extension XMLDecoderImplementation {
     }
 
     func unbox<T: Decodable>(_ box: Box) throws -> T {
-
+        
         let decoded: T?
         let type = T.self
-        
-        print("test", box)
         
         if type == Date.self || type == NSDate.self {
             let date: Date = try unbox(box)

--- a/Sources/XMLCoder/Decoder/XMLDecoderImplementation.swift
+++ b/Sources/XMLCoder/Decoder/XMLDecoderImplementation.swift
@@ -94,6 +94,7 @@ class XMLDecoderImplementation: Decoder {
                 )
             )
         case let choice as ChoiceBox:
+            precondition(choice.element.isNull)
             return KeyedDecodingContainer(XMLKeyedDecodingContainer<Key>(
                 referencing: self,
                 wrapping: SharedBox(KeyedBox(

--- a/Sources/XMLCoder/Decoder/XMLDecoderImplementation.swift
+++ b/Sources/XMLCoder/Decoder/XMLDecoderImplementation.swift
@@ -93,15 +93,6 @@ class XMLDecoderImplementation: Decoder {
                     """
                 )
             )
-        case let choice as ChoiceBox:
-            precondition(choice.element.isNull)
-            return KeyedDecodingContainer(XMLKeyedDecodingContainer<Key>(
-                referencing: self,
-                wrapping: SharedBox(KeyedBox(
-                    elements: KeyedStorage([(choice.key, NullBox())]),
-                    attributes: KeyedStorage()
-                ))
-            ))
         case let singleElement as SingleElementBox:
             precondition(singleElement.element.isNull)
             return KeyedDecodingContainer(XMLKeyedDecodingContainer<Key>(

--- a/Sources/XMLCoder/Decoder/XMLDecoderImplementation.swift
+++ b/Sources/XMLCoder/Decoder/XMLDecoderImplementation.swift
@@ -93,6 +93,14 @@ class XMLDecoderImplementation: Decoder {
                     """
                 )
             )
+        case let choice as ChoiceBox:
+            return KeyedDecodingContainer(XMLKeyedDecodingContainer<Key>(
+                referencing: self,
+                wrapping: SharedBox(KeyedBox(
+                    elements: KeyedStorage([(choice.key, NullBox())]),
+                    attributes: KeyedStorage()
+                ))
+            ))
         case let string as StringBox:
             return KeyedDecodingContainer(XMLKeyedDecodingContainer<Key>(
                 referencing: self,

--- a/Sources/XMLCoder/Decoder/XMLDecoderImplementation.swift
+++ b/Sources/XMLCoder/Decoder/XMLDecoderImplementation.swift
@@ -102,6 +102,15 @@ class XMLDecoderImplementation: Decoder {
                     attributes: KeyedStorage()
                 ))
             ))
+        case let singleElement as SingleElementBox:
+            precondition(singleElement.element.isNull)
+            return KeyedDecodingContainer(XMLKeyedDecodingContainer<Key>(
+                referencing: self,
+                wrapping: SharedBox(KeyedBox(
+                    elements: KeyedStorage([(singleElement.key, NullBox())]),
+                    attributes: KeyedStorage()
+                ))
+            ))
         case let string as StringBox:
             return KeyedDecodingContainer(XMLKeyedDecodingContainer<Key>(
                 referencing: self,

--- a/Sources/XMLCoder/Decoder/XMLDecoderImplementation.swift
+++ b/Sources/XMLCoder/Decoder/XMLDecoderImplementation.swift
@@ -419,10 +419,9 @@ extension XMLDecoderImplementation {
     }
 
     func unbox<T: Decodable>(_ box: Box) throws -> T {
-        
         let decoded: T?
         let type = T.self
-        
+
         if type == Date.self || type == NSDate.self {
             let date: Date = try unbox(box)
             decoded = date as? T
@@ -444,7 +443,7 @@ extension XMLDecoderImplementation {
             defer {
                 storage.popContainer()
             }
-            
+
             do {
                 decoded = try type.init(from: self)
             } catch {

--- a/Sources/XMLCoder/Decoder/XMLDecoderImplementation.swift
+++ b/Sources/XMLCoder/Decoder/XMLDecoderImplementation.swift
@@ -72,8 +72,10 @@ class XMLDecoderImplementation: Decoder {
 
     public func container<Key>(keyedBy keyType: Key.Type) throws -> KeyedDecodingContainer<Key> {
         if Key.self is XMLChoiceKey.Type {
+            print("choice route")
             return try choiceContainer(keyedBy: keyType)
         } else {
+            print("keyed route")
             return try keyedContainer(keyedBy: keyType)
         }
     }
@@ -414,7 +416,9 @@ extension XMLDecoderImplementation {
 
         let decoded: T?
         let type = T.self
-
+        
+        print("test", box)
+        
         if type == Date.self || type == NSDate.self {
             let date: Date = try unbox(box)
             decoded = date as? T
@@ -436,7 +440,7 @@ extension XMLDecoderImplementation {
             defer {
                 storage.popContainer()
             }
-
+            
             do {
                 decoded = try type.init(from: self)
             } catch {

--- a/Sources/XMLCoder/Decoder/XMLKeyedDecodingContainer.swift
+++ b/Sources/XMLCoder/Decoder/XMLKeyedDecodingContainer.swift
@@ -277,7 +277,6 @@ extension XMLKeyedDecodingContainer {
                 } else {
                     return keyedBox.elements[key.stringValue].map {
                         if let choice = $0 as? ChoiceBox {
-                            print(choice.element)
                             return choice.element
                         } else {
                             return $0

--- a/Sources/XMLCoder/Decoder/XMLKeyedDecodingContainer.swift
+++ b/Sources/XMLCoder/Decoder/XMLKeyedDecodingContainer.swift
@@ -110,6 +110,8 @@ struct XMLKeyedDecodingContainer<K: CodingKey>: KeyedDecodingContainerProtocol {
             return keyedBox.elements[key.stringValue].map {
                 if let choice = $0 as? ChoiceBox {
                     return choice.element
+                } else if let singleElement = $0 as? SingleElementBox {
+                    return singleElement.element
                 } else {
                     return $0
                 }

--- a/Sources/XMLCoder/Decoder/XMLKeyedDecodingContainer.swift
+++ b/Sources/XMLCoder/Decoder/XMLKeyedDecodingContainer.swift
@@ -275,7 +275,14 @@ extension XMLKeyedDecodingContainer {
                         return []
                     }
                 } else {
-                    return keyedBox.elements[key.stringValue]
+                    return keyedBox.elements[key.stringValue].map {
+                        if let choice = $0 as? ChoiceBox {
+                            print(choice.element)
+                            return choice.element
+                        } else {
+                            return $0
+                        }
+                    }
                 }
             }
 

--- a/Sources/XMLCoder/Decoder/XMLKeyedDecodingContainer.swift
+++ b/Sources/XMLCoder/Decoder/XMLKeyedDecodingContainer.swift
@@ -280,6 +280,8 @@ extension XMLKeyedDecodingContainer {
                         return value.map {
                             if let choice = $0 as? ChoiceBox {
                                 return choice.element
+                            } else if let singleElement = $0 as? SingleElementBox {
+                                return singleElement.element
                             } else {
                                 return $0
                             }
@@ -293,6 +295,8 @@ extension XMLKeyedDecodingContainer {
                     return keyedBox.elements[key.stringValue].map {
                         if let choice = $0 as? ChoiceBox {
                             return choice.element
+                        } else if let singleElement = $0 as? SingleElementBox {
+                            return singleElement.element
                         } else {
                             return $0
                         }

--- a/Tests/XMLCoderTests/NestedChoiceTests.swift
+++ b/Tests/XMLCoderTests/NestedChoiceTests.swift
@@ -191,6 +191,7 @@ class NestedChoiceTests: XCTestCase {
         let xml = """
          <container>
              <p>
+                 <br></br>
                  <run>
                      <id>1518</id>
                      <text>I am answering it again.</text>
@@ -205,6 +206,7 @@ class NestedChoiceTests: XCTestCase {
                      <id>1519</id>
                      <text>I am answering it again.</text>
                  </run>
+                 <br />
              </p>
          </container>
          """
@@ -213,6 +215,7 @@ class NestedChoiceTests: XCTestCase {
             paragraphs: [
                 Paragraph(
                     entries: [
+                        .br(Break()),
                         .run(Run(id: 1518, text: "I am answering it again.")),
                         .properties(Properties(id: 431, title: "A Word About Wake Times")),
                     ]
@@ -220,6 +223,7 @@ class NestedChoiceTests: XCTestCase {
                 Paragraph(
                     entries: [
                         .run(Run(id: 1519, text: "I am answering it again.")),
+                        .br(Break()),
                     ]
                 )
             ]

--- a/Tests/XMLCoderTests/SimpleChoiceTests.swift
+++ b/Tests/XMLCoderTests/SimpleChoiceTests.swift
@@ -31,7 +31,6 @@ extension IntOrString: Codable {
 
     init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
-        print(type(of: container))
         do {
             self = .int(try container.decode(Int.self, forKey: .int))
         } catch {

--- a/XMLCoder.xcodeproj/xcshareddata/xcschemes/XMLCoder.xcscheme
+++ b/XMLCoder.xcodeproj/xcshareddata/xcschemes/XMLCoder.xcscheme
@@ -37,11 +37,6 @@
                BlueprintName = "XMLCoderTests"
                ReferencedContainer = "container:XMLCoder.xcodeproj">
             </BuildableReference>
-            <SkippedTests>
-               <Test
-                  Identifier = "BenchmarkTests">
-               </Test>
-            </SkippedTests>
          </TestableReference>
       </Testables>
       <AdditionalOptions>

--- a/XMLCoder.xcodeproj/xcshareddata/xcschemes/XMLCoder.xcscheme
+++ b/XMLCoder.xcodeproj/xcshareddata/xcschemes/XMLCoder.xcscheme
@@ -37,8 +37,15 @@
                BlueprintName = "XMLCoderTests"
                ReferencedContainer = "container:XMLCoder.xcodeproj">
             </BuildableReference>
+            <SkippedTests>
+               <Test
+                  Identifier = "BenchmarkTests">
+               </Test>
+            </SkippedTests>
          </TestableReference>
       </Testables>
+      <AdditionalOptions>
+      </AdditionalOptions>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"
@@ -59,6 +66,8 @@
             ReferencedContainer = "container:XMLCoder.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"


### PR DESCRIPTION
Wraps null elements in a `ChoiceBox` so that they get picked up in the `XMLChoiceKey` case and can  be unwrapped to reveal a `NullBox` otherwise. 
Fixes #27 