### PR TITLE
Clean up encoding of choice elements

### DIFF
--- a/Sources/XMLCoder/Auxiliaries/KeyedStorage.swift
+++ b/Sources/XMLCoder/Auxiliaries/KeyedStorage.swift
@@ -83,7 +83,7 @@ extension KeyedStorage where Key == String, Value == Box {
         } else if let value = element.value {
             result.append(StringBox(value), at: element.key)
         } else {
-            result.append(NullBox(), at: element.key)
+            result.append(ChoiceBox(key: element.key, element: NullBox()), at: element.key)
         }
 
         return result

--- a/Sources/XMLCoder/Auxiliaries/XMLCoderElement.swift
+++ b/Sources/XMLCoder/Auxiliaries/XMLCoderElement.swift
@@ -101,13 +101,10 @@ struct XMLCoderElement: Equatable {
         prettyPrinted: Bool
     ) -> String {
         var string = ""
-        // Fix added for empty key adjustment in `UnkeyedBox` taking static func builder
-        let nonEmptyKey = element.key != ""
-        let level = nonEmptyKey ? level + 1 : level
         string += element._toXMLString(
-            indented: level, withCDATA: cdata, formatting: formatting
+            indented: level + 1, withCDATA: cdata, formatting: formatting
         )
-        string += (prettyPrinted && nonEmptyKey) ? "\n" : ""
+        string += prettyPrinted ? "\n" : ""
         return string
     }
 

--- a/Sources/XMLCoder/Auxiliaries/XMLCoderElement.swift
+++ b/Sources/XMLCoder/Auxiliaries/XMLCoderElement.swift
@@ -249,14 +249,16 @@ struct XMLCoderElement: Equatable {
 extension XMLCoderElement {
 
     init(key: String, box: UnkeyedBox) {
-        if box is [SingleElementBox] {
-            self.init(key: key, elements: box.map { XMLCoderElement(key: "", box: $0) })
+        if let containsChoice = box as? [ChoiceBox] {
+            self.init(key: key, elements: containsChoice.map {
+                return XMLCoderElement(key: $0.key, box: $0.element)
+            })
         } else {
             self.init(key: key, elements: box.map { XMLCoderElement(key: key, box: $0) })
         }
     }
     
-    init(key: String, box: SingleElementBox) {
+    init(key: String, box: ChoiceBox) {
         self.init(key: key, elements: [XMLCoderElement(key: box.key, box: box.element)])
     }
 
@@ -312,14 +314,14 @@ extension XMLCoderElement {
             self.init(key: key, box: sharedUnkeyedBox.unboxed)
         case let sharedKeyedBox as SharedBox<KeyedBox>:
             self.init(key: key, box: sharedKeyedBox.unboxed)
-        case let sharedSingleElementBox as SharedBox<SingleElementBox>:
-            self.init(key: key, box: sharedSingleElementBox.unboxed)
+        case let sharedChoiceBox as SharedBox<ChoiceBox>:
+            self.init(key: key, box: sharedChoiceBox.unboxed)
         case let unkeyedBox as UnkeyedBox:
             self.init(key: key, box: unkeyedBox)
         case let keyedBox as KeyedBox:
             self.init(key: key, box: keyedBox)
-        case let singleElementBox as SingleElementBox:
-            self.init(key: key, box: singleElementBox)
+        case let choiceBox as ChoiceBox:
+            self.init(key: key, box: choiceBox)
         case let simpleBox as SimpleBox:
             self.init(key: key, box: simpleBox)
         case let box:

--- a/Sources/XMLCoder/Decoder/XMLDecoderImplementation.swift
+++ b/Sources/XMLCoder/Decoder/XMLDecoderImplementation.swift
@@ -72,10 +72,8 @@ class XMLDecoderImplementation: Decoder {
 
     public func container<Key>(keyedBy keyType: Key.Type) throws -> KeyedDecodingContainer<Key> {
         if Key.self is XMLChoiceKey.Type {
-            print("choice route")
             return try choiceContainer(keyedBy: keyType)
         } else {
-            print("keyed route")
             return try keyedContainer(keyedBy: keyType)
         }
     }
@@ -413,11 +411,9 @@ extension XMLDecoderImplementation {
     }
 
     func unbox<T: Decodable>(_ box: Box) throws -> T {
-
+        
         let decoded: T?
         let type = T.self
-        
-        print("test", box)
         
         if type == Date.self || type == NSDate.self {
             let date: Date = try unbox(box)

--- a/Sources/XMLCoder/Decoder/XMLDecoderImplementation.swift
+++ b/Sources/XMLCoder/Decoder/XMLDecoderImplementation.swift
@@ -93,6 +93,14 @@ class XMLDecoderImplementation: Decoder {
                     """
                 )
             )
+        case let choice as ChoiceBox:
+            return KeyedDecodingContainer(XMLKeyedDecodingContainer<Key>(
+                referencing: self,
+                wrapping: SharedBox(KeyedBox(
+                    elements: KeyedStorage([(choice.key, NullBox())]),
+                    attributes: KeyedStorage()
+                ))
+            ))
         case let string as StringBox:
             return KeyedDecodingContainer(XMLKeyedDecodingContainer<Key>(
                 referencing: self,

--- a/Sources/XMLCoder/Decoder/XMLDecoderImplementation.swift
+++ b/Sources/XMLCoder/Decoder/XMLDecoderImplementation.swift
@@ -419,10 +419,9 @@ extension XMLDecoderImplementation {
     }
 
     func unbox<T: Decodable>(_ box: Box) throws -> T {
-        
         let decoded: T?
         let type = T.self
-        
+
         if type == Date.self || type == NSDate.self {
             let date: Date = try unbox(box)
             decoded = date as? T
@@ -444,7 +443,7 @@ extension XMLDecoderImplementation {
             defer {
                 storage.popContainer()
             }
-            
+
             do {
                 decoded = try type.init(from: self)
             } catch {

--- a/Sources/XMLCoder/Decoder/XMLDecoderImplementation.swift
+++ b/Sources/XMLCoder/Decoder/XMLDecoderImplementation.swift
@@ -72,8 +72,10 @@ class XMLDecoderImplementation: Decoder {
 
     public func container<Key>(keyedBy keyType: Key.Type) throws -> KeyedDecodingContainer<Key> {
         if Key.self is XMLChoiceKey.Type {
+            print("choice route")
             return try choiceContainer(keyedBy: keyType)
         } else {
+            print("keyed route")
             return try keyedContainer(keyedBy: keyType)
         }
     }
@@ -414,7 +416,9 @@ extension XMLDecoderImplementation {
 
         let decoded: T?
         let type = T.self
-
+        
+        print("test", box)
+        
         if type == Date.self || type == NSDate.self {
             let date: Date = try unbox(box)
             decoded = date as? T
@@ -436,7 +440,7 @@ extension XMLDecoderImplementation {
             defer {
                 storage.popContainer()
             }
-
+            
             do {
                 decoded = try type.init(from: self)
             } catch {

--- a/Sources/XMLCoder/Decoder/XMLKeyedDecodingContainer.swift
+++ b/Sources/XMLCoder/Decoder/XMLKeyedDecodingContainer.swift
@@ -277,7 +277,6 @@ extension XMLKeyedDecodingContainer {
                 } else {
                     return keyedBox.elements[key.stringValue].map {
                         if let choice = $0 as? ChoiceBox {
-                            print(choice.element)
                             return choice.element
                         } else {
                             return $0

--- a/Sources/XMLCoder/Decoder/XMLKeyedDecodingContainer.swift
+++ b/Sources/XMLCoder/Decoder/XMLKeyedDecodingContainer.swift
@@ -275,7 +275,14 @@ extension XMLKeyedDecodingContainer {
                         return []
                     }
                 } else {
-                    return keyedBox.elements[key.stringValue]
+                    return keyedBox.elements[key.stringValue].map {
+                        if let choice = $0 as? ChoiceBox {
+                            print(choice.element)
+                            return choice.element
+                        } else {
+                            return $0
+                        }
+                    }
                 }
             }
 

--- a/Sources/XMLCoder/Encoder/XMLEncoder.swift
+++ b/Sources/XMLCoder/Encoder/XMLEncoder.swift
@@ -338,8 +338,8 @@ open class XMLEncoder {
             elementOrNone = XMLCoderElement(key: rootKey, box: keyedBox)
         } else if let unkeyedBox = topLevel as? UnkeyedBox {
             elementOrNone = XMLCoderElement(key: rootKey, box: unkeyedBox)
-        } else if let singleElementBox = topLevel as? SingleElementBox {
-            elementOrNone = XMLCoderElement(key: rootKey, box: singleElementBox)
+        } else if let choiceBox = topLevel as? ChoiceBox {
+            elementOrNone = XMLCoderElement(key: rootKey, box: choiceBox)
         } else {
             fatalError("Unrecognized top-level element of type: \(type(of: topLevel))")
         }

--- a/Sources/XMLCoder/Encoder/XMLEncoderImplementation.swift
+++ b/Sources/XMLCoder/Encoder/XMLEncoderImplementation.swift
@@ -65,7 +65,7 @@ class XMLEncoderImplementation: Encoder {
     
     public func container<Key>(keyedBy _: Key.Type) -> KeyedEncodingContainer<Key> {
         if Key.self is XMLChoiceKey.Type {
-            return singleElementContainer(keyedBy: Key.self)
+            return choiceContainer(keyedBy: Key.self)
         } else {
             return keyedContainer(keyedBy: Key.self)
         }
@@ -89,20 +89,20 @@ class XMLEncoderImplementation: Encoder {
         return KeyedEncodingContainer(container)
     }
     
-    public func singleElementContainer<Key>(keyedBy _: Key.Type) -> KeyedEncodingContainer<Key> {
-        let topContainer: SharedBox<SingleElementBox>
+    public func choiceContainer<Key>(keyedBy _: Key.Type) -> KeyedEncodingContainer<Key> {
+        let topContainer: SharedBox<ChoiceBox>
         if canEncodeNewValue {
             // We haven't yet pushed a container at this level; do so here.
-            topContainer = storage.pushSingleElementContainer()
+            topContainer = storage.pushChoiceContainer()
         } else {
-            guard let container = storage.lastContainer as? SharedBox<SingleElementBox> else {
+            guard let container = storage.lastContainer as? SharedBox<ChoiceBox> else {
                 preconditionFailure("Attempt to push new (single element) keyed encoding container when already previously encoded at this path.")
             }
             
             topContainer = container
         }
         
-        let container = XMLSingleElementEncodingContainer<Key>(referencing: self, codingPath: codingPath, wrapping: topContainer)
+        let container = XMLChoiceEncodingContainer<Key>(referencing: self, codingPath: codingPath, wrapping: topContainer)
         return KeyedEncodingContainer(container)
     }
 

--- a/Sources/XMLCoder/Encoder/XMLEncodingStorage.swift
+++ b/Sources/XMLCoder/Encoder/XMLEncodingStorage.swift
@@ -37,8 +37,8 @@ struct XMLEncodingStorage {
         return container
     }
     
-    mutating func pushSingleElementContainer() -> SharedBox<SingleElementBox> {
-        let container = SharedBox(SingleElementBox())
+    mutating func pushChoiceContainer() -> SharedBox<ChoiceBox> {
+        let container = SharedBox(ChoiceBox())
         containers.append(container)
         return container
     }

--- a/Sources/XMLCoder/Encoder/XMLKeyedEncodingContainer.swift
+++ b/Sources/XMLCoder/Encoder/XMLKeyedEncodingContainer.swift
@@ -174,19 +174,19 @@ struct XMLKeyedEncodingContainer<K: CodingKey>: KeyedEncodingContainerProtocol {
         keyedBy _: NestedKey.Type,
         forKey key: Key
         ) -> KeyedEncodingContainer<NestedKey> {
-        let sharedSingleElement = SharedBox(SingleElementBox())
+        let sharedChoice = SharedBox(ChoiceBox())
         
         self.container.withShared { container in
-            container.elements.append(sharedSingleElement, at: _converted(key).stringValue)
+            container.elements.append(sharedChoice, at: _converted(key).stringValue)
         }
         
         codingPath.append(key)
         defer { self.codingPath.removeLast() }
         
-        let container = XMLSingleElementEncodingContainer<NestedKey>(
+        let container = XMLChoiceEncodingContainer<NestedKey>(
             referencing: encoder,
             codingPath: codingPath,
-            wrapping: sharedSingleElement
+            wrapping: sharedChoice
         )
         return KeyedEncodingContainer(container)
     }

--- a/Sources/XMLCoder/Encoder/XMLReferencingEncoder.swift
+++ b/Sources/XMLCoder/Encoder/XMLReferencingEncoder.swift
@@ -26,7 +26,7 @@ class XMLReferencingEncoder: XMLEncoderImplementation {
         case keyed(SharedBox<KeyedBox>, String)
         
         /// Referencing a specific key in a keyed container.
-        case singleElement(SharedBox<SingleElementBox>, String)
+        case choice(SharedBox<ChoiceBox>, String)
     }
 
     // MARK: - Properties
@@ -78,10 +78,10 @@ class XMLReferencingEncoder: XMLEncoderImplementation {
         referencing encoder: XMLEncoderImplementation,
         key: CodingKey,
         convertedKey: CodingKey,
-        wrapping sharedKeyed: SharedBox<SingleElementBox>
+        wrapping sharedKeyed: SharedBox<ChoiceBox>
         ) {
         self.encoder = encoder
-        reference = .singleElement(sharedKeyed, convertedKey.stringValue)
+        reference = .choice(sharedKeyed, convertedKey.stringValue)
         super.init(
             options: encoder.options,
             nodeEncodings: encoder.nodeEncodings,
@@ -120,10 +120,10 @@ class XMLReferencingEncoder: XMLEncoderImplementation {
             sharedKeyedBox.withShared { keyedBox in
                 keyedBox.elements.append(box, at: key)
             }
-        case let .singleElement(sharedSingleElementBox, key):
-            sharedSingleElementBox.withShared { singleElementBox in
-                singleElementBox.element = box
-                singleElementBox.key = key
+        case let .choice(sharedChoiceBox, key):
+            sharedChoiceBox.withShared { choiceBox in
+                choiceBox.element = box
+                choiceBox.key = key
             }
         }
     }

--- a/Sources/XMLCoder/Encoder/XMLUnkeyedEncodingContainer.swift
+++ b/Sources/XMLCoder/Encoder/XMLUnkeyedEncodingContainer.swift
@@ -67,7 +67,7 @@ struct XMLUnkeyedEncodingContainer: UnkeyedEncodingContainer {
         keyedBy _: NestedKey.Type
         ) -> KeyedEncodingContainer<NestedKey> {
         if NestedKey.self is XMLChoiceKey.Type {
-            return nestedSingleElementContainer(keyedBy: NestedKey.self)
+            return nestedChoiceContainer(keyedBy: NestedKey.self)
         } else {
             return nestedKeyedContainer(keyedBy: NestedKey.self)
         }
@@ -90,19 +90,19 @@ struct XMLUnkeyedEncodingContainer: UnkeyedEncodingContainer {
         return KeyedEncodingContainer(container)
     }
     
-    public mutating func nestedSingleElementContainer<NestedKey>(keyedBy _: NestedKey.Type) -> KeyedEncodingContainer<NestedKey> {
+    public mutating func nestedChoiceContainer<NestedKey>(keyedBy _: NestedKey.Type) -> KeyedEncodingContainer<NestedKey> {
         codingPath.append(XMLKey(index: count))
         defer { self.codingPath.removeLast() }
         
-        let sharedSingleElement = SharedBox(SingleElementBox())
+        let sharedChoice = SharedBox(ChoiceBox())
         self.container.withShared { container in
-            container.append(sharedSingleElement)
+            container.append(sharedChoice)
         }
         
-        let container = XMLSingleElementEncodingContainer<NestedKey>(
+        let container = XMLChoiceEncodingContainer<NestedKey>(
             referencing: encoder,
             codingPath: codingPath,
-            wrapping: sharedSingleElement
+            wrapping: sharedChoice
         )
         return KeyedEncodingContainer(container)
     }

--- a/Tests/XMLCoderTests/NestedAttributeChoiceTests.swift
+++ b/Tests/XMLCoderTests/NestedAttributeChoiceTests.swift
@@ -1,0 +1,144 @@
+//
+//  NestedAttributeChoiceTests.swift
+//  XMLCoderTests
+//
+//  Created by Benjamin Wetherfield on 7/23/19.
+//
+
+import XCTest
+import XMLCoder
+
+private struct Container: Equatable {
+    let paragraphs: [Paragraph]
+}
+
+private struct Paragraph: Equatable {
+    let entries: [Entry]
+}
+
+private enum Entry: Equatable {
+    case run(Run)
+    case properties(Properties)
+    case br(Break)
+}
+
+private struct Run: Codable, Equatable, DynamicNodeEncoding {
+    let id: Int
+    let text: String
+    
+    static func nodeEncoding(for key: CodingKey) -> XMLEncoder.NodeEncoding {
+        switch key {
+        case CodingKeys.id:
+            return .attribute
+        default:
+            return .element
+        }
+    }
+}
+
+private struct Properties: Codable, Equatable, DynamicNodeEncoding {
+    let id: Int
+    let title: String
+    
+    static func nodeEncoding(for key: CodingKey) -> XMLEncoder.NodeEncoding {
+        return .attribute
+    }
+}
+
+private struct Break: Codable, Equatable { }
+
+extension Container: Codable {
+    enum CodingKeys: String, CodingKey {
+        case paragraphs = "p"
+    }
+}
+
+extension Paragraph: Codable {
+    init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        self.entries = try container.decode([Entry].self)
+    }
+    
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        try container.encode(entries)
+    }
+}
+
+extension Entry: Codable {
+    private enum CodingKeys: String, XMLChoiceKey {
+        case run, properties, br
+    }
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        do {
+            self = .run(try container.decode(Run.self, forKey: .run))
+        } catch {
+            do {
+                self = .properties(try container.decode(Properties.self, forKey: .properties))
+            } catch {
+                self = .br(try container.decode(Break.self, forKey: .br))
+            }
+        }
+    }
+    
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        switch self {
+        case let .run(value):
+            try container.encode(value, forKey: .run)
+        case let .properties(value):
+            try container.encode(value, forKey: .properties)
+        case let .br(value):
+            try container.encode(value, forKey: .br)
+        }
+    }
+}
+
+class NestedAttributeChoiceTests: XCTestCase {
+    
+    private var encoder: XMLEncoder {
+        let encoder = XMLEncoder()
+        encoder.outputFormatting = [.prettyPrinted]
+        return encoder
+    }
+
+    func testNestedEnumsEncoding() throws {
+        let xml = """
+         <container>
+             <p>
+                 <br />
+                 <run id="1518">
+                     <text>I am answering it again.</text>
+                 </run>
+                 <properties id="431" title="A Word About Wake Times" />
+             </p>
+             <p>
+                 <run id="1519">
+                     <text>I am answering it again.</text>
+                 </run>
+                 <br />
+             </p>
+         </container>
+         """
+        let value = Container(
+            paragraphs: [
+                Paragraph(
+                    entries: [
+                        .br(Break()),
+                        .run(Run(id: 1518, text: "I am answering it again.")),
+                        .properties(Properties(id: 431, title: "A Word About Wake Times")),
+                    ]
+                ),
+                Paragraph(
+                    entries: [
+                        .run(Run(id: 1519, text: "I am answering it again.")),
+                        .br(Break()),
+                    ]
+                )
+            ]
+        )
+        let encoded = try encoder.encode(value, withRootKey: "container")
+        XCTAssertEqual(String(data: encoded, encoding: .utf8), xml)
+    }
+}

--- a/Tests/XMLCoderTests/NestedChoiceTests.swift
+++ b/Tests/XMLCoderTests/NestedChoiceTests.swift
@@ -191,6 +191,7 @@ class NestedChoiceTests: XCTestCase {
         let xml = """
          <container>
              <p>
+                 <br></br>
                  <run>
                      <id>1518</id>
                      <text>I am answering it again.</text>
@@ -205,6 +206,7 @@ class NestedChoiceTests: XCTestCase {
                      <id>1519</id>
                      <text>I am answering it again.</text>
                  </run>
+                 <br />
              </p>
          </container>
          """
@@ -213,6 +215,7 @@ class NestedChoiceTests: XCTestCase {
             paragraphs: [
                 Paragraph(
                     entries: [
+                        .br(Break()),
                         .run(Run(id: 1518, text: "I am answering it again.")),
                         .properties(Properties(id: 431, title: "A Word About Wake Times")),
                     ]
@@ -220,6 +223,7 @@ class NestedChoiceTests: XCTestCase {
                 Paragraph(
                     entries: [
                         .run(Run(id: 1519, text: "I am answering it again.")),
+                        .br(Break()),
                     ]
                 )
             ]

--- a/Tests/XMLCoderTests/SimpleChoiceTests.swift
+++ b/Tests/XMLCoderTests/SimpleChoiceTests.swift
@@ -31,7 +31,6 @@ extension IntOrString: Codable {
 
     init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
-        print(type(of: container))
         do {
             self = .int(try container.decode(Int.self, forKey: .int))
         } catch {

--- a/XMLCoder.xcodeproj/project.pbxproj
+++ b/XMLCoder.xcodeproj/project.pbxproj
@@ -39,8 +39,9 @@
 		B3BE1D652202CB7200259831 /* SingleValueEncodingContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3BE1D642202CB7200259831 /* SingleValueEncodingContainer.swift */; };
 		B3BE1D682202CBF800259831 /* XMLDecoderImplementation.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3BE1D662202CBF800259831 /* XMLDecoderImplementation.swift */; };
 		B3BE1D692202CBF800259831 /* SingleValueDecodingContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3BE1D672202CBF800259831 /* SingleValueDecodingContainer.swift */; };
+		B50E7B4122E78FE1009D37E4 /* NestedAttributeChoiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B50E7B4022E78FE1009D37E4 /* NestedAttributeChoiceTests.swift */; };
 		B54B122E22DF916F0014109D /* XMLChoiceKey.swift in Sources */ = {isa = PBXBuildFile; fileRef = B54B122D22DF916F0014109D /* XMLChoiceKey.swift */; };
-		B54B123022DF921B0014109D /* XMLSingleElementEncodingContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = B54B122F22DF921B0014109D /* XMLSingleElementEncodingContainer.swift */; };
+		B54B123022DF921B0014109D /* XMLChoiceEncodingContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = B54B122F22DF921B0014109D /* XMLChoiceEncodingContainer.swift */; };
 		BF63EF0021CCDED2001D38C5 /* XMLStackParserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF63EEFF21CCDED2001D38C5 /* XMLStackParserTests.swift */; };
 		BF63EF0621CD7A74001D38C5 /* URLBox.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF63EF0521CD7A74001D38C5 /* URLBox.swift */; };
 		BF63EF0821CD7AF8001D38C5 /* URLBoxTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF63EF0721CD7AF8001D38C5 /* URLBoxTests.swift */; };
@@ -170,8 +171,9 @@
 		B3BE1D642202CB7200259831 /* SingleValueEncodingContainer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SingleValueEncodingContainer.swift; sourceTree = "<group>"; };
 		B3BE1D662202CBF800259831 /* XMLDecoderImplementation.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = XMLDecoderImplementation.swift; sourceTree = "<group>"; };
 		B3BE1D672202CBF800259831 /* SingleValueDecodingContainer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SingleValueDecodingContainer.swift; sourceTree = "<group>"; };
+		B50E7B4022E78FE1009D37E4 /* NestedAttributeChoiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NestedAttributeChoiceTests.swift; sourceTree = "<group>"; };
 		B54B122D22DF916F0014109D /* XMLChoiceKey.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XMLChoiceKey.swift; sourceTree = "<group>"; };
-		B54B122F22DF921B0014109D /* XMLSingleElementEncodingContainer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XMLSingleElementEncodingContainer.swift; sourceTree = "<group>"; };
+		B54B122F22DF921B0014109D /* XMLChoiceEncodingContainer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XMLChoiceEncodingContainer.swift; sourceTree = "<group>"; };
 		BF63EEFF21CCDED2001D38C5 /* XMLStackParserTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XMLStackParserTests.swift; sourceTree = "<group>"; };
 		BF63EF0521CD7A74001D38C5 /* URLBox.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLBox.swift; sourceTree = "<group>"; };
 		BF63EF0721CD7AF8001D38C5 /* URLBoxTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLBoxTests.swift; sourceTree = "<group>"; };
@@ -395,7 +397,7 @@
 				B3BE1D622202CB1400259831 /* XMLEncoderImplementation.swift */,
 				OBJ_18 /* XMLEncodingStorage.swift */,
 				OBJ_19 /* XMLKeyedEncodingContainer.swift */,
-				B54B122F22DF921B0014109D /* XMLSingleElementEncodingContainer.swift */,
+				B54B122F22DF921B0014109D /* XMLChoiceEncodingContainer.swift */,
 				OBJ_20 /* XMLReferencingEncoder.swift */,
 				OBJ_21 /* XMLUnkeyedEncodingContainer.swift */,
 			);
@@ -422,6 +424,7 @@
 				1482D5A122DD2D9400AE2D6E /* SimpleChoiceTests.swift */,
 				1482D5A322DD2F4D00AE2D6E /* CompositeChoiceTests.swift */,
 				1482D5A922DD961E00AE2D6E /* NestedChoiceTests.swift */,
+				B50E7B4022E78FE1009D37E4 /* NestedAttributeChoiceTests.swift */,
 				OBJ_28 /* BooksTest.swift */,
 				D1B6A2C02297EF5A005B8A6E /* BorderTest.swift */,
 				OBJ_29 /* BreakfastTest.swift */,
@@ -652,7 +655,7 @@
 				BF9457A921CBB498005ACFDE /* KeyedBox.swift in Sources */,
 				BF9457D721CBB59E005ACFDE /* IntBox.swift in Sources */,
 				BF9457AD21CBB498005ACFDE /* BoolBox.swift in Sources */,
-				B54B123022DF921B0014109D /* XMLSingleElementEncodingContainer.swift in Sources */,
+				B54B123022DF921B0014109D /* XMLChoiceEncodingContainer.swift in Sources */,
 				BF9457B821CBB4DB005ACFDE /* String+Extensions.swift in Sources */,
 				BF9457AE21CBB498005ACFDE /* Box.swift in Sources */,
 				BF9457DA21CBB5D2005ACFDE /* DataBox.swift in Sources */,
@@ -684,6 +687,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 0;
 			files = (
+				B50E7B4122E78FE1009D37E4 /* NestedAttributeChoiceTests.swift in Sources */,
 				BF9457CB21CBB516005ACFDE /* DecimalBoxTests.swift in Sources */,
 				BF9457F221CBB6BC005ACFDE /* UnkeyedTests.swift in Sources */,
 				A61FE03C21E4EAB10015D993 /* KeyedIntTests.swift in Sources */,

--- a/XMLCoder.xcodeproj/xcshareddata/xcschemes/XMLCoder.xcscheme
+++ b/XMLCoder.xcodeproj/xcshareddata/xcschemes/XMLCoder.xcscheme
@@ -37,11 +37,6 @@
                BlueprintName = "XMLCoderTests"
                ReferencedContainer = "container:XMLCoder.xcodeproj">
             </BuildableReference>
-            <SkippedTests>
-               <Test
-                  Identifier = "BenchmarkTests">
-               </Test>
-            </SkippedTests>
          </TestableReference>
       </Testables>
       <AdditionalOptions>

--- a/XMLCoder.xcodeproj/xcshareddata/xcschemes/XMLCoder.xcscheme
+++ b/XMLCoder.xcodeproj/xcshareddata/xcschemes/XMLCoder.xcscheme
@@ -37,8 +37,15 @@
                BlueprintName = "XMLCoderTests"
                ReferencedContainer = "container:XMLCoder.xcodeproj">
             </BuildableReference>
+            <SkippedTests>
+               <Test
+                  Identifier = "BenchmarkTests">
+               </Test>
+            </SkippedTests>
          </TestableReference>
       </Testables>
+      <AdditionalOptions>
+      </AdditionalOptions>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"
@@ -59,6 +66,8 @@
             ReferencedContainer = "container:XMLCoder.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"


### PR DESCRIPTION
* Fixes a bug involving pretty printing
    - Shifts meaningful logic back up to `XMLCoderElement` layer (rather than in string manipulation)
* Removes some redundant attribute code (that relied upon `SingleElement` types).
* Removes all uses of `SingleElement` on the encode side and replaces with `ChoiceBox`
* Adds test for encoding choice elements in structures that "contain" attributes (they are really separated by one layer of abstraction) 
