### PR TITLE
Rename XMLChoiceKey -> XMLChoiceCodingKey

### DIFF
--- a/Sources/XMLCoder/Auxiliaries/XMLChoiceCodingKey.swift
+++ b/Sources/XMLCoder/Auxiliaries/XMLChoiceCodingKey.swift
@@ -5,4 +5,6 @@
 //  Created by Benjamin Wetherfield on 7/17/19.
 //
 
+/// An empty marker protocol that can be used in place of `CodingKey`. It must be used when conforming a union-type–like enum with
+/// associated values to `Codable` when the encoded format is `XML`.
 public protocol XMLChoiceCodingKey: CodingKey {}

--- a/Sources/XMLCoder/Auxiliaries/XMLChoiceCodingKey.swift
+++ b/Sources/XMLCoder/Auxiliaries/XMLChoiceCodingKey.swift
@@ -1,0 +1,8 @@
+//
+//  XMLChoiceCodingKey.swift
+//  XMLCoder
+//
+//  Created by Benjamin Wetherfield on 7/17/19.
+//
+
+public protocol XMLChoiceCodingKey: CodingKey {}

--- a/Sources/XMLCoder/Auxiliaries/XMLChoiceKey.swift
+++ b/Sources/XMLCoder/Auxiliaries/XMLChoiceKey.swift
@@ -1,8 +1,0 @@
-//
-//  XMLChoiceKey.swift
-//  XMLCoder
-//
-//  Created by Benjamin Wetherfield on 7/17/19.
-//
-
-public protocol XMLChoiceKey: CodingKey {}

--- a/Sources/XMLCoder/Decoder/XMLChoiceDecodingContainer.swift
+++ b/Sources/XMLCoder/Decoder/XMLChoiceDecodingContainer.swift
@@ -83,7 +83,7 @@ struct XMLChoiceDecodingContainer<K: CodingKey>: KeyedDecodingContainerProtocol 
     }
 
     public func decode<T: Decodable>(_ type: T.Type, forKey key: Key) throws -> T {
-        guard container.withShared({ $0.key == key.stringValue }), key is XMLChoiceKey else {
+        guard container.withShared({ $0.key == key.stringValue }), key is XMLChoiceCodingKey else {
             throw DecodingError.typeMismatch(
                 at: codingPath,
                 expectation: type,

--- a/Sources/XMLCoder/Decoder/XMLDecoderImplementation.swift
+++ b/Sources/XMLCoder/Decoder/XMLDecoderImplementation.swift
@@ -71,7 +71,7 @@ class XMLDecoderImplementation: Decoder {
     }
 
     public func container<Key>(keyedBy keyType: Key.Type) throws -> KeyedDecodingContainer<Key> {
-        if Key.self is XMLChoiceKey.Type {
+        if Key.self is XMLChoiceCodingKey.Type {
             return try choiceContainer(keyedBy: keyType)
         } else {
             return try keyedContainer(keyedBy: keyType)

--- a/Sources/XMLCoder/Encoder/XMLChoiceEncodingContainer.swift
+++ b/Sources/XMLCoder/Encoder/XMLChoiceEncodingContainer.swift
@@ -120,7 +120,7 @@ struct XMLChoiceEncodingContainer<K: CodingKey>: KeyedEncodingContainerProtocol 
         keyedBy _: NestedKey.Type,
         forKey key: Key
         ) -> KeyedEncodingContainer<NestedKey> {
-        if NestedKey.self is XMLChoiceKey.Type {
+        if NestedKey.self is XMLChoiceCodingKey.Type {
             return nestedChoiceContainer(keyedBy: NestedKey.self, forKey: key)
         } else {
             return nestedKeyedContainer(keyedBy: NestedKey.self, forKey: key)

--- a/Sources/XMLCoder/Encoder/XMLEncoderImplementation.swift
+++ b/Sources/XMLCoder/Encoder/XMLEncoderImplementation.swift
@@ -64,7 +64,7 @@ class XMLEncoderImplementation: Encoder {
     // MARK: - Encoder Methods
     
     public func container<Key>(keyedBy _: Key.Type) -> KeyedEncodingContainer<Key> {
-        if Key.self is XMLChoiceKey.Type {
+        if Key.self is XMLChoiceCodingKey.Type {
             return choiceContainer(keyedBy: Key.self)
         } else {
             return keyedContainer(keyedBy: Key.self)

--- a/Sources/XMLCoder/Encoder/XMLKeyedEncodingContainer.swift
+++ b/Sources/XMLCoder/Encoder/XMLKeyedEncodingContainer.swift
@@ -142,7 +142,7 @@ struct XMLKeyedEncodingContainer<K: CodingKey>: KeyedEncodingContainerProtocol {
         keyedBy _: NestedKey.Type,
         forKey key: Key
     ) -> KeyedEncodingContainer<NestedKey> {
-        if NestedKey.self is XMLChoiceKey.Type {
+        if NestedKey.self is XMLChoiceCodingKey.Type {
             return nestedSingleElementContainer(keyedBy: NestedKey.self, forKey: key)
         } else {
             return nestedKeyedContainer(keyedBy: NestedKey.self, forKey: key)

--- a/Sources/XMLCoder/Encoder/XMLUnkeyedEncodingContainer.swift
+++ b/Sources/XMLCoder/Encoder/XMLUnkeyedEncodingContainer.swift
@@ -66,7 +66,7 @@ struct XMLUnkeyedEncodingContainer: UnkeyedEncodingContainer {
     public mutating func nestedContainer<NestedKey>(
         keyedBy _: NestedKey.Type
         ) -> KeyedEncodingContainer<NestedKey> {
-        if NestedKey.self is XMLChoiceKey.Type {
+        if NestedKey.self is XMLChoiceCodingKey.Type {
             return nestedChoiceContainer(keyedBy: NestedKey.self)
         } else {
             return nestedKeyedContainer(keyedBy: NestedKey.self)

--- a/Tests/XMLCoderTests/CompositeChoiceTests.swift
+++ b/Tests/XMLCoderTests/CompositeChoiceTests.swift
@@ -22,7 +22,7 @@ private enum IntOrStringWrapper: Equatable {
 }
 
 extension IntOrStringWrapper: Codable {
-    enum CodingKeys: String, XMLChoiceKey {
+    enum CodingKeys: String, XMLChoiceCodingKey {
         case int
         case string
     }

--- a/Tests/XMLCoderTests/NestedAttributeChoiceTests.swift
+++ b/Tests/XMLCoderTests/NestedAttributeChoiceTests.swift
@@ -66,7 +66,7 @@ extension Paragraph: Codable {
 }
 
 extension Entry: Codable {
-    private enum CodingKeys: String, XMLChoiceKey {
+    private enum CodingKeys: String, XMLChoiceCodingKey {
         case run, properties, br
     }
     public init(from decoder: Decoder) throws {

--- a/Tests/XMLCoderTests/NestedChoiceTests.swift
+++ b/Tests/XMLCoderTests/NestedChoiceTests.swift
@@ -53,7 +53,7 @@ extension Paragraph: Codable {
 }
 
 extension Entry: Codable {
-    private enum CodingKeys: String, XMLChoiceKey {
+    private enum CodingKeys: String, XMLChoiceCodingKey {
         case run, properties, br
     }
     public init(from decoder: Decoder) throws {

--- a/Tests/XMLCoderTests/SimpleChoiceTests.swift
+++ b/Tests/XMLCoderTests/SimpleChoiceTests.swift
@@ -14,7 +14,7 @@ private enum IntOrString: Equatable {
 }
 
 extension IntOrString: Codable {
-    enum CodingKeys: String, XMLChoiceKey {
+    enum CodingKeys: String, XMLChoiceCodingKey {
         case int
         case string
     }

--- a/XMLCoder.xcodeproj/project.pbxproj
+++ b/XMLCoder.xcodeproj/project.pbxproj
@@ -39,7 +39,7 @@
 		B3BE1D682202CBF800259831 /* XMLDecoderImplementation.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3BE1D662202CBF800259831 /* XMLDecoderImplementation.swift */; };
 		B3BE1D692202CBF800259831 /* SingleValueDecodingContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3BE1D672202CBF800259831 /* SingleValueDecodingContainer.swift */; };
 		B50E7B4122E78FE1009D37E4 /* NestedAttributeChoiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B50E7B4022E78FE1009D37E4 /* NestedAttributeChoiceTests.swift */; };
-		B54B122E22DF916F0014109D /* XMLChoiceKey.swift in Sources */ = {isa = PBXBuildFile; fileRef = B54B122D22DF916F0014109D /* XMLChoiceKey.swift */; };
+		B54B122E22DF916F0014109D /* XMLChoiceCodingKey.swift in Sources */ = {isa = PBXBuildFile; fileRef = B54B122D22DF916F0014109D /* XMLChoiceCodingKey.swift */; };
 		B54B123022DF921B0014109D /* XMLChoiceEncodingContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = B54B122F22DF921B0014109D /* XMLChoiceEncodingContainer.swift */; };
 		BF63EF0021CCDED2001D38C5 /* XMLStackParserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF63EEFF21CCDED2001D38C5 /* XMLStackParserTests.swift */; };
 		BF63EF0621CD7A74001D38C5 /* URLBox.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF63EF0521CD7A74001D38C5 /* URLBox.swift */; };
@@ -170,7 +170,7 @@
 		B3BE1D662202CBF800259831 /* XMLDecoderImplementation.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = XMLDecoderImplementation.swift; sourceTree = "<group>"; };
 		B3BE1D672202CBF800259831 /* SingleValueDecodingContainer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SingleValueDecodingContainer.swift; sourceTree = "<group>"; };
 		B50E7B4022E78FE1009D37E4 /* NestedAttributeChoiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NestedAttributeChoiceTests.swift; sourceTree = "<group>"; };
-		B54B122D22DF916F0014109D /* XMLChoiceKey.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XMLChoiceKey.swift; sourceTree = "<group>"; };
+		B54B122D22DF916F0014109D /* XMLChoiceCodingKey.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XMLChoiceCodingKey.swift; sourceTree = "<group>"; };
 		B54B122F22DF921B0014109D /* XMLChoiceEncodingContainer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XMLChoiceEncodingContainer.swift; sourceTree = "<group>"; };
 		BF63EEFF21CCDED2001D38C5 /* XMLStackParserTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XMLStackParserTests.swift; sourceTree = "<group>"; };
 		BF63EF0521CD7A74001D38C5 /* URLBox.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLBox.swift; sourceTree = "<group>"; };
@@ -336,7 +336,7 @@
 				BF9457B121CBB4DB005ACFDE /* XMLHeader.swift */,
 				BF9457B321CBB4DB005ACFDE /* XMLStackParser.swift */,
 				BF9457B521CBB4DB005ACFDE /* XMLKey.swift */,
-				B54B122D22DF916F0014109D /* XMLChoiceKey.swift */,
+				B54B122D22DF916F0014109D /* XMLChoiceCodingKey.swift */,
 			);
 			path = Auxiliaries;
 			sourceTree = "<group>";
@@ -641,7 +641,7 @@
 				D1EC3E65225A38EC00C610E3 /* KeyedStorage.swift in Sources */,
 				OBJ_51 /* XMLKeyedDecodingContainer.swift in Sources */,
 				OBJ_52 /* XMLUnkeyedDecodingContainer.swift in Sources */,
-				B54B122E22DF916F0014109D /* XMLChoiceKey.swift in Sources */,
+				B54B122E22DF916F0014109D /* XMLChoiceCodingKey.swift in Sources */,
 				OBJ_53 /* EncodingErrorExtension.swift in Sources */,
 				BF9457B921CBB4DB005ACFDE /* XMLStackParser.swift in Sources */,
 				OBJ_54 /* XMLEncoder.swift in Sources */,


### PR DESCRIPTION
This PR renames `XMLChoiceKey` to `XMLChoiceCodingKey`, as it reveals to passersby the inherited protocol requirements of `CodingKey`.

A doc comment is also added for better ergonomics all around.

Closes #26.