### PR TITLE
Tidy up implementation of XMLChoiceDecodingContainer

### DIFF
--- a/Sources/XMLCoder/Decoder/XMLChoiceDecodingContainer.swift
+++ b/Sources/XMLCoder/Decoder/XMLChoiceDecodingContainer.swift
@@ -114,42 +114,6 @@ struct XMLChoiceDecodingContainer<K: CodingKey>: KeyedDecodingContainerProtocol 
 
 /// Private functions
 extension XMLChoiceDecodingContainer {
-    private func _errorDescription(of key: CodingKey) -> String {
-        switch decoder.options.keyDecodingStrategy {
-        case .convertFromSnakeCase:
-            // In this case we can attempt to recover the original value by
-            // reversing the transform
-            let original = key.stringValue
-            let converted = XMLEncoder.KeyEncodingStrategy
-                ._convertToSnakeCase(original)
-            if converted == original {
-                return "\(key) (\"\(original)\")"
-            } else {
-                return "\(key) (\"\(original)\"), converted to \(converted)"
-            }
-        default:
-            // Otherwise, just report the converted string
-            return "\(key) (\"\(key.stringValue)\")"
-        }
-    }
-
-    private func decodeSignedInteger<T>(_ type: T.Type,
-                                        forKey key: Key) throws -> T
-        where T: BinaryInteger & SignedInteger & Decodable {
-            return try decodeConcrete(type, forKey: key)
-    }
-
-    private func decodeUnsignedInteger<T>(_ type: T.Type,
-                                          forKey key: Key) throws -> T
-        where T: BinaryInteger & UnsignedInteger & Decodable {
-            return try decodeConcrete(type, forKey: key)
-    }
-
-    private func decodeFloatingPoint<T>(_ type: T.Type,
-                                        forKey key: Key) throws -> T
-        where T: BinaryFloatingPoint & Decodable {
-            return try decodeConcrete(type, forKey: key)
-    }
 
     private func decodeConcrete<T: Decodable>(
         _ type: T.Type,

--- a/Sources/XMLCoder/Decoder/XMLChoiceDecodingContainer.swift
+++ b/Sources/XMLCoder/Decoder/XMLChoiceDecodingContainer.swift
@@ -84,18 +84,10 @@ struct XMLChoiceDecodingContainer<K: CodingKey>: KeyedDecodingContainerProtocol 
 
     public func decode<T: Decodable>(_ type: T.Type, forKey key: Key) throws -> T {
         guard container.withShared({ $0.key == key.stringValue }), key is XMLChoiceKey else {
-            throw DecodingError.typeMismatch(
-                at: codingPath,
-                expectation: type,
-                reality: container
-            )
+            throw DecodingError.typeMismatch(at: codingPath, expectation: type, reality: container)
         }
         guard let strategy = self.decoder.nodeDecodings.last else {
-            preconditionFailure(
-                """
-                Attempt to access node decoding strategy from empty stack.
-                """
-            )
+            preconditionFailure("Attempt to access node decoding strategy from empty stack.")
         }
         decoder.codingPath.append(key)
         let nodeDecodings = decoder.options.nodeDecodingStrategy.nodeDecodings(

--- a/Sources/XMLCoder/Decoder/XMLChoiceDecodingContainer.swift
+++ b/Sources/XMLCoder/Decoder/XMLChoiceDecodingContainer.swift
@@ -104,11 +104,11 @@ struct XMLChoiceDecodingContainer<K: CodingKey>: KeyedDecodingContainerProtocol 
     }
 
     public func superDecoder() throws -> Decoder {
-        return try _superDecoder(forKey: XMLKey.super)
+        fatalError("XMLChoiceDecodingContainer cannot produce a super decoder.")
     }
 
     public func superDecoder(forKey key: Key) throws -> Decoder {
-        return try _superDecoder(forKey: key)
+        fatalError("XMLChoiceDecodingContainer cannot produce a super decoder.")
     }
 }
 
@@ -137,17 +137,5 @@ extension XMLChoiceDecodingContainer {
             decoder.codingPath.removeLast()
         }
         return try decoder.unbox(container.withShared { $0.element })
-    }
-
-    private func _superDecoder(forKey key: CodingKey) throws -> Decoder {
-        decoder.codingPath.append(key)
-        defer { decoder.codingPath.removeLast() }
-        let box: Box = container.withShared { $0.element }
-        return XMLDecoderImplementation(
-            referencing: box,
-            options: decoder.options,
-            nodeDecodings: decoder.nodeDecodings,
-            codingPath: decoder.codingPath
-        )
     }
 }

--- a/Sources/XMLCoder/Decoder/XMLChoiceDecodingContainer.swift
+++ b/Sources/XMLCoder/Decoder/XMLChoiceDecodingContainer.swift
@@ -90,35 +90,6 @@ struct XMLChoiceDecodingContainer<K: CodingKey>: KeyedDecodingContainerProtocol 
                 reality: container
             )
         }
-        return try decodeConcrete(type, forKey: key)
-    }
-
-    public func nestedContainer<NestedKey>(
-        keyedBy _: NestedKey.Type, forKey key: Key
-    ) throws -> KeyedDecodingContainer<NestedKey> {
-        fatalError("Choice elements cannot produce a nested container.")
-    }
-
-    public func nestedUnkeyedContainer(forKey key: Key) throws -> UnkeyedDecodingContainer {
-        fatalError("Choice elements cannot produce a unkeyed nested container.")
-    }
-
-    public func superDecoder() throws -> Decoder {
-        fatalError("XMLChoiceDecodingContainer cannot produce a super decoder.")
-    }
-
-    public func superDecoder(forKey key: Key) throws -> Decoder {
-        fatalError("XMLChoiceDecodingContainer cannot produce a super decoder.")
-    }
-}
-
-/// Private functions
-extension XMLChoiceDecodingContainer {
-
-    private func decodeConcrete<T: Decodable>(
-        _ type: T.Type,
-        forKey key: Key
-    ) throws -> T {
         guard let strategy = self.decoder.nodeDecodings.last else {
             preconditionFailure(
                 """
@@ -137,5 +108,23 @@ extension XMLChoiceDecodingContainer {
             decoder.codingPath.removeLast()
         }
         return try decoder.unbox(container.withShared { $0.element })
+    }
+
+    public func nestedContainer<NestedKey>(
+        keyedBy _: NestedKey.Type, forKey key: Key
+    ) throws -> KeyedDecodingContainer<NestedKey> {
+        fatalError("Choice elements cannot produce a nested container.")
+    }
+
+    public func nestedUnkeyedContainer(forKey key: Key) throws -> UnkeyedDecodingContainer {
+        fatalError("Choice elements cannot produce a unkeyed nested container.")
+    }
+
+    public func superDecoder() throws -> Decoder {
+        fatalError("XMLChoiceDecodingContainer cannot produce a super decoder.")
+    }
+
+    public func superDecoder(forKey key: Key) throws -> Decoder {
+        fatalError("XMLChoiceDecodingContainer cannot produce a super decoder.")
     }
 }

--- a/Sources/XMLCoder/Decoder/XMLChoiceDecodingContainer.swift
+++ b/Sources/XMLCoder/Decoder/XMLChoiceDecodingContainer.swift
@@ -83,7 +83,7 @@ struct XMLChoiceDecodingContainer<K: CodingKey>: KeyedDecodingContainerProtocol 
     }
 
     public func decode<T: Decodable>(_ type: T.Type, forKey key: Key) throws -> T {
-        guard container.withShared({ $0.key == key.stringValue }), key is XMLChoiceKey else {
+        guard container.withShared({ $0.key == key.stringValue }), key is XMLChoiceCodingKey else {
             throw DecodingError.typeMismatch(at: codingPath, expectation: type, reality: container)
         }
         guard let strategy = self.decoder.nodeDecodings.last else {

--- a/XMLCoder.xcodeproj/xcshareddata/xcschemes/XMLCoder.xcscheme
+++ b/XMLCoder.xcodeproj/xcshareddata/xcschemes/XMLCoder.xcscheme
@@ -39,8 +39,6 @@
             </BuildableReference>
          </TestableReference>
       </Testables>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"
@@ -61,8 +59,6 @@
             ReferencedContainer = "container:XMLCoder.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"


### PR DESCRIPTION
This PR just cleans up aspects of the `XMLChoiceDecodingContainer` implementation.

It now `fatalError`s if you try to create a `super` decoder, as an enum _can't_ have a super class (it ain't a class).