### PR TITLE
Remove Foundation imports where unnecessary

### DIFF
--- a/Sources/XMLCoder/Auxiliaries/Box/ChoiceBox.swift
+++ b/Sources/XMLCoder/Auxiliaries/Box/ChoiceBox.swift
@@ -31,7 +31,7 @@ extension ChoiceBox {
         self.init(key: firstKey, element: firstElement)
     }
 
-    init(_ singleElementBox: SingleElementBox) {
+    init(_ singleElementBox: SingleKeyedBox) {
         self.init(key: singleElementBox.key, element: singleElementBox.element)
     }
 }

--- a/Sources/XMLCoder/Auxiliaries/Box/ChoiceBox.swift
+++ b/Sources/XMLCoder/Auxiliaries/Box/ChoiceBox.swift
@@ -31,7 +31,7 @@ extension ChoiceBox {
         self.init(key: firstKey, element: firstElement)
     }
 
-    init(_ singleElementBox: SingleKeyedBox) {
-        self.init(key: singleElementBox.key, element: singleElementBox.element)
+    init(_ singleKeyedBox: SingleKeyedBox) {
+        self.init(key: singleKeyedBox.key, element: singleKeyedBox.element)
     }
 }

--- a/Sources/XMLCoder/Auxiliaries/Box/SingleKeyedBox.swift
+++ b/Sources/XMLCoder/Auxiliaries/Box/SingleKeyedBox.swift
@@ -1,5 +1,5 @@
 //
-//  SingleElementBox.swift
+//  SingleKeyedBox.swift
 //  XMLCoder
 //
 //  Created by James Bean on 7/15/19.
@@ -8,7 +8,7 @@
 /// A `Box` which contains a single `key` and `element` pair. This is useful for disambiguating elements which could either represent
 /// an element nested in a keyed or unkeyed container, or an choice between multiple known-typed values (implemented in Swift using
 /// enums with associated values).
-struct SingleElementBox: SimpleBox {
+struct SingleKeyedBox: SimpleBox {
     typealias Key = String
     typealias Attribute = SimpleBox
     typealias Attributes = KeyedStorage<Key, Attribute>
@@ -18,7 +18,7 @@ struct SingleElementBox: SimpleBox {
     var element: Box = NullBox()
 }
 
-extension SingleElementBox: Box {
+extension SingleKeyedBox: Box {
     var isNull: Bool {
         return false
     }
@@ -28,7 +28,7 @@ extension SingleElementBox: Box {
     }
 }
 
-extension SingleElementBox {
+extension SingleKeyedBox {
     init?(_ keyedBox: KeyedBox) {
         guard let firstKey = keyedBox.elements.keys.first else { return nil }
         let firstElement = keyedBox.elements[firstKey]

--- a/Sources/XMLCoder/Auxiliaries/Box/SingleKeyedBox.swift
+++ b/Sources/XMLCoder/Auxiliaries/Box/SingleKeyedBox.swift
@@ -9,13 +9,8 @@
 /// an element nested in a keyed or unkeyed container, or an choice between multiple known-typed values (implemented in Swift using
 /// enums with associated values).
 struct SingleKeyedBox: SimpleBox {
-    typealias Key = String
-    typealias Attribute = SimpleBox
-    typealias Attributes = KeyedStorage<Key, Attribute>
-    
-    var attributes = Attributes()
-    var key: String = ""
-    var element: Box = NullBox()
+    var key: String
+    var element: Box
 }
 
 extension SingleKeyedBox: Box {

--- a/Sources/XMLCoder/Auxiliaries/Box/SingleKeyedBox.swift
+++ b/Sources/XMLCoder/Auxiliaries/Box/SingleKeyedBox.swift
@@ -27,11 +27,3 @@ extension SingleKeyedBox: Box {
         return nil
     }
 }
-
-extension SingleKeyedBox {
-    init?(_ keyedBox: KeyedBox) {
-        guard let firstKey = keyedBox.elements.keys.first else { return nil }
-        let firstElement = keyedBox.elements[firstKey]
-        self.init(attributes: keyedBox.attributes, key: firstKey, element: firstElement)
-    }
-}

--- a/Sources/XMLCoder/Auxiliaries/KeyedStorage.swift
+++ b/Sources/XMLCoder/Auxiliaries/KeyedStorage.swift
@@ -83,7 +83,7 @@ extension KeyedStorage where Key == String, Value == Box {
         } else if let value = element.value {
             result.append(StringBox(value), at: element.key)
         } else {
-            result.append(SingleKeyedBox(attributes: .init(), key: element.key, element: NullBox()), at: element.key)
+            result.append(SingleKeyedBox(key: element.key, element: NullBox()), at: element.key)
         }
 
         return result

--- a/Sources/XMLCoder/Auxiliaries/KeyedStorage.swift
+++ b/Sources/XMLCoder/Auxiliaries/KeyedStorage.swift
@@ -83,7 +83,7 @@ extension KeyedStorage where Key == String, Value == Box {
         } else if let value = element.value {
             result.append(StringBox(value), at: element.key)
         } else {
-            result.append(SingleElementBox(attributes: .init(), key: element.key, element: NullBox()), at: element.key)
+            result.append(SingleKeyedBox(attributes: .init(), key: element.key, element: NullBox()), at: element.key)
         }
 
         return result

--- a/Sources/XMLCoder/Decoder/XMLChoiceDecodingContainer.swift
+++ b/Sources/XMLCoder/Decoder/XMLChoiceDecodingContainer.swift
@@ -5,8 +5,6 @@
 //  Created by James Bean on 7/18/19.
 //
 
-import Foundation
-
 /// Container specialized for decoding XML choice elements.
 struct XMLChoiceDecodingContainer<K: CodingKey>: KeyedDecodingContainerProtocol {
     typealias Key = K

--- a/Sources/XMLCoder/Decoder/XMLDecoderImplementation.swift
+++ b/Sources/XMLCoder/Decoder/XMLDecoderImplementation.swift
@@ -185,7 +185,7 @@ class XMLDecoderImplementation: Decoder {
                 referencing: self,
                 wrapping: SharedBox(
                     keyed.withShared { $0.elements.map { key, box in
-                        SingleKeyedBox(attributes: .init(), key: key, element: box)
+                        SingleKeyedBox(key: key, element: box)
                     }
                 }
                 )

--- a/Sources/XMLCoder/Decoder/XMLDecoderImplementation.swift
+++ b/Sources/XMLCoder/Decoder/XMLDecoderImplementation.swift
@@ -93,12 +93,12 @@ class XMLDecoderImplementation: Decoder {
                     """
                 )
             )
-        case let singleElement as SingleKeyedBox:
-            precondition(singleElement.element.isNull)
+        case let singleKeyed as SingleKeyedBox:
+            precondition(singleKeyed.element.isNull)
             return KeyedDecodingContainer(XMLKeyedDecodingContainer<Key>(
                 referencing: self,
                 wrapping: SharedBox(KeyedBox(
-                    elements: KeyedStorage([(singleElement.key, NullBox())]),
+                    elements: KeyedStorage([(singleKeyed.key, NullBox())]),
                     attributes: KeyedStorage()
                 ))
             ))
@@ -140,8 +140,8 @@ class XMLDecoderImplementation: Decoder {
         switch topContainer {
         case let choice as ChoiceBox:
             choiceBox = choice
-        case let singleElement as SingleKeyedBox:
-            choiceBox = ChoiceBox(singleElement)
+        case let singleKeyed as SingleKeyedBox:
+            choiceBox = ChoiceBox(singleKeyed)
         case let keyed as SharedBox<KeyedBox>:
             choiceBox = ChoiceBox(keyed.withShared { $0 })
         default:

--- a/Sources/XMLCoder/Decoder/XMLDecoderImplementation.swift
+++ b/Sources/XMLCoder/Decoder/XMLDecoderImplementation.swift
@@ -93,7 +93,7 @@ class XMLDecoderImplementation: Decoder {
                     """
                 )
             )
-        case let singleElement as SingleElementBox:
+        case let singleElement as SingleKeyedBox:
             precondition(singleElement.element.isNull)
             return KeyedDecodingContainer(XMLKeyedDecodingContainer<Key>(
                 referencing: self,
@@ -140,7 +140,7 @@ class XMLDecoderImplementation: Decoder {
         switch topContainer {
         case let choice as ChoiceBox:
             choiceBox = choice
-        case let singleElement as SingleElementBox:
+        case let singleElement as SingleKeyedBox:
             choiceBox = ChoiceBox(singleElement)
         case let keyed as SharedBox<KeyedBox>:
             choiceBox = ChoiceBox(keyed.withShared { $0 })
@@ -185,7 +185,7 @@ class XMLDecoderImplementation: Decoder {
                 referencing: self,
                 wrapping: SharedBox(
                     keyed.withShared { $0.elements.map { key, box in
-                        SingleElementBox(attributes: .init(), key: key, element: box)
+                        SingleKeyedBox(attributes: .init(), key: key, element: box)
                     }
                 }
                 )

--- a/Sources/XMLCoder/Decoder/XMLKeyedDecodingContainer.swift
+++ b/Sources/XMLCoder/Decoder/XMLKeyedDecodingContainer.swift
@@ -110,8 +110,8 @@ struct XMLKeyedDecodingContainer<K: CodingKey>: KeyedDecodingContainerProtocol {
             return keyedBox.elements[key.stringValue].map {
                 if let choice = $0 as? ChoiceBox {
                     return choice.element
-                } else if let singleElement = $0 as? SingleKeyedBox {
-                    return singleElement.element
+                } else if let singleKeyed = $0 as? SingleKeyedBox {
+                    return singleKeyed.element
                 } else {
                     return $0
                 }
@@ -280,8 +280,8 @@ extension XMLKeyedDecodingContainer {
                         return value.map {
                             if let choice = $0 as? ChoiceBox {
                                 return choice.element
-                            } else if let singleElement = $0 as? SingleKeyedBox {
-                                return singleElement.element
+                            } else if let singleKeyed = $0 as? SingleKeyedBox {
+                                return singleKeyed.element
                             } else {
                                 return $0
                             }
@@ -295,8 +295,8 @@ extension XMLKeyedDecodingContainer {
                     return keyedBox.elements[key.stringValue].map {
                         if let choice = $0 as? ChoiceBox {
                             return choice.element
-                        } else if let singleElement = $0 as? SingleKeyedBox {
-                            return singleElement.element
+                        } else if let singleKeyed = $0 as? SingleKeyedBox {
+                            return singleKeyed.element
                         } else {
                             return $0
                         }

--- a/Sources/XMLCoder/Decoder/XMLKeyedDecodingContainer.swift
+++ b/Sources/XMLCoder/Decoder/XMLKeyedDecodingContainer.swift
@@ -110,7 +110,7 @@ struct XMLKeyedDecodingContainer<K: CodingKey>: KeyedDecodingContainerProtocol {
             return keyedBox.elements[key.stringValue].map {
                 if let choice = $0 as? ChoiceBox {
                     return choice.element
-                } else if let singleElement = $0 as? SingleElementBox {
+                } else if let singleElement = $0 as? SingleKeyedBox {
                     return singleElement.element
                 } else {
                     return $0
@@ -280,7 +280,7 @@ extension XMLKeyedDecodingContainer {
                         return value.map {
                             if let choice = $0 as? ChoiceBox {
                                 return choice.element
-                            } else if let singleElement = $0 as? SingleElementBox {
+                            } else if let singleElement = $0 as? SingleKeyedBox {
                                 return singleElement.element
                             } else {
                                 return $0
@@ -295,7 +295,7 @@ extension XMLKeyedDecodingContainer {
                     return keyedBox.elements[key.stringValue].map {
                         if let choice = $0 as? ChoiceBox {
                             return choice.element
-                        } else if let singleElement = $0 as? SingleElementBox {
+                        } else if let singleElement = $0 as? SingleKeyedBox {
                             return singleElement.element
                         } else {
                             return $0

--- a/Sources/XMLCoder/Decoder/XMLUnkeyedDecodingContainer.swift
+++ b/Sources/XMLCoder/Decoder/XMLUnkeyedDecodingContainer.swift
@@ -103,7 +103,7 @@ struct XMLUnkeyedDecodingContainer: UnkeyedDecodingContainer {
         }
 
         var value: T?
-        if let singleElement = box as? SingleElementBox {
+        if let singleElement = box as? SingleKeyedBox {
             do {
                 // Drill down to the element in the case of an nested unkeyed element
                 value = try decode(decoder, singleElement.element)

--- a/Sources/XMLCoder/Decoder/XMLUnkeyedDecodingContainer.swift
+++ b/Sources/XMLCoder/Decoder/XMLUnkeyedDecodingContainer.swift
@@ -103,13 +103,13 @@ struct XMLUnkeyedDecodingContainer: UnkeyedDecodingContainer {
         }
 
         var value: T?
-        if let singleElement = box as? SingleKeyedBox {
+        if let singleKeyed = box as? SingleKeyedBox {
             do {
                 // Drill down to the element in the case of an nested unkeyed element
-                value = try decode(decoder, singleElement.element)
+                value = try decode(decoder, singleKeyed.element)
             } catch {
                 // Specialize for choice elements
-                value = try decode(decoder, ChoiceBox(key: singleElement.key, element: singleElement.element))
+                value = try decode(decoder, ChoiceBox(key: singleKeyed.key, element: singleKeyed.element))
             }
         } else {
             value = try decode(decoder, box)

--- a/Sources/XMLCoder/Encoder/XMLChoiceEncodingContainer.swift
+++ b/Sources/XMLCoder/Encoder/XMLChoiceEncodingContainer.swift
@@ -1,5 +1,5 @@
 //
-//  XMLSingleElementEncodingContainer.swift
+//  XMLChoiceEncodingContainer.swift
 //  XMLCoder
 //
 //  Created by Benjamin Wetherfield on 7/17/19.

--- a/Sources/XMLCoder/Encoder/XMLChoiceEncodingContainer.swift
+++ b/Sources/XMLCoder/Encoder/XMLChoiceEncodingContainer.swift
@@ -5,8 +5,6 @@
 //  Created by Benjamin Wetherfield on 7/17/19.
 //
 
-import Foundation
-
 struct XMLChoiceEncodingContainer<K: CodingKey>: KeyedEncodingContainerProtocol {
     typealias Key = K
     

--- a/Sources/XMLCoder/Encoder/XMLKeyedEncodingContainer.swift
+++ b/Sources/XMLCoder/Encoder/XMLKeyedEncodingContainer.swift
@@ -143,7 +143,7 @@ struct XMLKeyedEncodingContainer<K: CodingKey>: KeyedEncodingContainerProtocol {
         forKey key: Key
     ) -> KeyedEncodingContainer<NestedKey> {
         if NestedKey.self is XMLChoiceCodingKey.Type {
-            return nestedSingleElementContainer(keyedBy: NestedKey.self, forKey: key)
+            return nestedChoiceContainer(keyedBy: NestedKey.self, forKey: key)
         } else {
             return nestedKeyedContainer(keyedBy: NestedKey.self, forKey: key)
         }
@@ -170,7 +170,7 @@ struct XMLKeyedEncodingContainer<K: CodingKey>: KeyedEncodingContainerProtocol {
         return KeyedEncodingContainer(container)
     }
     
-    mutating func nestedSingleElementContainer<NestedKey>(
+    mutating func nestedChoiceContainer<NestedKey>(
         keyedBy _: NestedKey.Type,
         forKey key: Key
         ) -> KeyedEncodingContainer<NestedKey> {

--- a/XMLCoder.xcodeproj/project.pbxproj
+++ b/XMLCoder.xcodeproj/project.pbxproj
@@ -23,7 +23,7 @@
 /* Begin PBXBuildFile section */
 		1482D5A222DD2D9400AE2D6E /* SimpleChoiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1482D5A122DD2D9400AE2D6E /* SimpleChoiceTests.swift */; };
 		1482D5A422DD2F4D00AE2D6E /* CompositeChoiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1482D5A322DD2F4D00AE2D6E /* CompositeChoiceTests.swift */; };
-		1482D5A822DD6AEE00AE2D6E /* SingleElementBox.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1482D5A722DD6AED00AE2D6E /* SingleElementBox.swift */; };
+		1482D5A822DD6AEE00AE2D6E /* SingleKeyedBox.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1482D5A722DD6AED00AE2D6E /* SingleKeyedBox.swift */; };
 		1482D5AA22DD961E00AE2D6E /* NestedChoiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1482D5A922DD961E00AE2D6E /* NestedChoiceTests.swift */; };
 		14AD38AF22E1218D008BF810 /* XMLChoiceDecodingContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14AD38AE22E1218D008BF810 /* XMLChoiceDecodingContainer.swift */; };
 		14AD38B122E16A8A008BF810 /* ChoiceBox.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14AD38B022E16A8A008BF810 /* ChoiceBox.swift */; };
@@ -154,7 +154,7 @@
 /* Begin PBXFileReference section */
 		1482D5A122DD2D9400AE2D6E /* SimpleChoiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SimpleChoiceTests.swift; sourceTree = "<group>"; };
 		1482D5A322DD2F4D00AE2D6E /* CompositeChoiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompositeChoiceTests.swift; sourceTree = "<group>"; };
-		1482D5A722DD6AED00AE2D6E /* SingleElementBox.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SingleElementBox.swift; sourceTree = "<group>"; };
+		1482D5A722DD6AED00AE2D6E /* SingleKeyedBox.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SingleKeyedBox.swift; sourceTree = "<group>"; };
 		1482D5A922DD961E00AE2D6E /* NestedChoiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NestedChoiceTests.swift; sourceTree = "<group>"; };
 		14AD38AE22E1218D008BF810 /* XMLChoiceDecodingContainer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XMLChoiceDecodingContainer.swift; sourceTree = "<group>"; };
 		14AD38B022E16A8A008BF810 /* ChoiceBox.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChoiceBox.swift; sourceTree = "<group>"; };
@@ -318,7 +318,7 @@
 				BF9457A021CBB497005ACFDE /* UnkeyedBox.swift */,
 				BF94579F21CBB497005ACFDE /* KeyedBox.swift */,
 				BF63EF1721CEB6BD001D38C5 /* SharedBox.swift */,
-				1482D5A722DD6AED00AE2D6E /* SingleElementBox.swift */,
+				1482D5A722DD6AED00AE2D6E /* SingleKeyedBox.swift */,
 				14AD38B022E16A8A008BF810 /* ChoiceBox.swift */,
 			);
 			path = Box;
@@ -656,7 +656,7 @@
 				BF9457AE21CBB498005ACFDE /* Box.swift in Sources */,
 				BF9457DA21CBB5D2005ACFDE /* DataBox.swift in Sources */,
 				BF9457AB21CBB498005ACFDE /* DecimalBox.swift in Sources */,
-				1482D5A822DD6AEE00AE2D6E /* SingleElementBox.swift in Sources */,
+				1482D5A822DD6AEE00AE2D6E /* SingleKeyedBox.swift in Sources */,
 				OBJ_56 /* XMLKeyedEncodingContainer.swift in Sources */,
 				14AD38B122E16A8A008BF810 /* ChoiceBox.swift in Sources */,
 				D158F12F2229892C0032B449 /* DynamicNodeDecoding.swift in Sources */,


### PR DESCRIPTION
This PR removes `Foundation` imports in the choice encoding and decoding container files.

It is built off of #36 and #37 but could rebased if those aren't desired.