### PR TITLE
There will be one key in XMLChoiceDecodingContainer

### DIFF
--- a/Sources/XMLCoder/Decoder/XMLChoiceDecodingContainer.swift
+++ b/Sources/XMLCoder/Decoder/XMLChoiceDecodingContainer.swift
@@ -69,7 +69,7 @@ struct XMLChoiceDecodingContainer<K: CodingKey>: KeyedDecodingContainerProtocol 
     // MARK: - KeyedDecodingContainerProtocol Methods
 
     public var allKeys: [Key] {
-        return container.withShared { Key(stringValue: $0.key) }.map { [$0] } ?? []
+        return container.withShared { [Key(stringValue: $0.key)!] }
     }
 
     public func contains(_ key: Key) -> Bool {


### PR DESCRIPTION
Currently, we are a little wish-washy w/r/t the `allKeys` property in `XMLChoiceDecodingContainer`. I don't _think_ it's possible to fail to create a `Key` with the `key` property on the `ChoiceBox`.

We should be confident and return a single key, instead of effectively silently failing if the `Key` initialization doesn't work.