### PR TITLE
Factor out key transformation to XMLDecoderImplementation.keyTransform

### DIFF
--- a/Sources/XMLCoder/Decoder/XMLChoiceDecodingContainer.swift
+++ b/Sources/XMLCoder/Decoder/XMLChoiceDecodingContainer.swift
@@ -25,43 +25,13 @@ struct XMLChoiceDecodingContainer<K: CodingKey>: KeyedDecodingContainerProtocol 
     /// Initializes `self` by referencing the given decoder and container.
     init(referencing decoder: XMLDecoderImplementation, wrapping container: SharedBox<ChoiceBox>) {
         self.decoder = decoder
-
-        func mapKeys(
-            _ container: SharedBox<ChoiceBox>, closure: (String) -> String
-        ) -> SharedBox<ChoiceBox> {
+        self.container = decoder.transformKeyedContainer { keyTransform in
             return SharedBox(
                 ChoiceBox(
-                    key: closure(container.withShared { $0.key }),
+                    key: keyTransform(container.withShared { $0.key }),
                     element: container.withShared { $0.element }
                 )
             )
-        }
-        // FIXME: Keep DRY from XMLKeyedDecodingContainer.init
-        switch decoder.options.keyDecodingStrategy {
-        case .useDefaultKeys:
-            self.container = container
-        case .convertFromSnakeCase:
-            // Convert the snake case keys in the container to camel case.
-            // If we hit a duplicate key after conversion, then we'll use the
-            // first one we saw. Effectively an undefined behavior with dictionaries.
-            self.container = mapKeys(container) { key in
-                XMLDecoder.KeyDecodingStrategy._convertFromSnakeCase(key)
-            }
-        case .convertFromKebabCase:
-            self.container = mapKeys(container) { key in
-                XMLDecoder.KeyDecodingStrategy._convertFromKebabCase(key)
-            }
-        case .convertFromCapitalized:
-            self.container = mapKeys(container) { key in
-                XMLDecoder.KeyDecodingStrategy._convertFromCapitalized(key)
-            }
-        case let .custom(converter):
-            self.container = mapKeys(container) { key in
-                let codingPath = decoder.codingPath + [
-                    XMLKey(stringValue: key, intValue: nil),
-                ]
-                return converter(codingPath).stringValue
-            }
         }
         codingPath = decoder.codingPath
     }

--- a/Sources/XMLCoder/Decoder/XMLChoiceDecodingContainer.swift
+++ b/Sources/XMLCoder/Decoder/XMLChoiceDecodingContainer.swift
@@ -25,11 +25,11 @@ struct XMLChoiceDecodingContainer<K: CodingKey>: KeyedDecodingContainerProtocol 
     /// Initializes `self` by referencing the given decoder and container.
     init(referencing decoder: XMLDecoderImplementation, wrapping container: SharedBox<ChoiceBox>) {
         self.decoder = decoder
-        self.container = decoder.transformKeyedContainer { keyTransform in
+        self.container = container.withShared { choiceBox in
             return SharedBox(
                 ChoiceBox(
-                    key: keyTransform(container.withShared { $0.key }),
-                    element: container.withShared { $0.element }
+                    key: decoder.keyTransform(choiceBox.key),
+                    element: choiceBox.element
                 )
             )
         }

--- a/Sources/XMLCoder/Decoder/XMLChoiceDecodingContainer.swift
+++ b/Sources/XMLCoder/Decoder/XMLChoiceDecodingContainer.swift
@@ -25,14 +25,8 @@ struct XMLChoiceDecodingContainer<K: CodingKey>: KeyedDecodingContainerProtocol 
     /// Initializes `self` by referencing the given decoder and container.
     init(referencing decoder: XMLDecoderImplementation, wrapping container: SharedBox<ChoiceBox>) {
         self.decoder = decoder
-        self.container = container.withShared { choiceBox in
-            return SharedBox(
-                ChoiceBox(
-                    key: decoder.keyTransform(choiceBox.key),
-                    element: choiceBox.element
-                )
-            )
-        }
+        container.withShared { $0.key = decoder.keyTransform($0.key) }
+        self.container = container
         codingPath = decoder.codingPath
     }
 

--- a/Sources/XMLCoder/Decoder/XMLDecoderImplementation.swift
+++ b/Sources/XMLCoder/Decoder/XMLDecoderImplementation.swift
@@ -476,14 +476,14 @@ extension XMLDecoderImplementation {
     ) -> Container {
         let keyTransform: (String) -> String
         switch options.keyDecodingStrategy {
-        case .useDefaultKeys:
-            keyTransform = { key in key }
         case .convertFromSnakeCase:
             keyTransform = XMLDecoder.KeyDecodingStrategy._convertFromSnakeCase
         case .convertFromCapitalized:
             keyTransform = XMLDecoder.KeyDecodingStrategy._convertFromCapitalized
         case .convertFromKebabCase:
             keyTransform = XMLDecoder.KeyDecodingStrategy._convertFromKebabCase
+        case .useDefaultKeys:
+            keyTransform = { key in key }
         case let .custom(converter):
             keyTransform = { key in
                 converter(self.codingPath + [XMLKey(stringValue: key, intValue: nil)]).stringValue

--- a/Sources/XMLCoder/Decoder/XMLDecoderImplementation.swift
+++ b/Sources/XMLCoder/Decoder/XMLDecoderImplementation.swift
@@ -471,24 +471,20 @@ extension XMLDecoderImplementation {
 }
 
 extension XMLDecoderImplementation {
-    func transformKeyedContainer <Container> (
-        _ transform: ((String) -> String) -> Container
-    ) -> Container {
-        let keyTransform: (String) -> String
+    var keyTransform: (String) -> String {
         switch options.keyDecodingStrategy {
         case .convertFromSnakeCase:
-            keyTransform = XMLDecoder.KeyDecodingStrategy._convertFromSnakeCase
+            return XMLDecoder.KeyDecodingStrategy._convertFromSnakeCase
         case .convertFromCapitalized:
-            keyTransform = XMLDecoder.KeyDecodingStrategy._convertFromCapitalized
+            return XMLDecoder.KeyDecodingStrategy._convertFromCapitalized
         case .convertFromKebabCase:
-            keyTransform = XMLDecoder.KeyDecodingStrategy._convertFromKebabCase
+            return XMLDecoder.KeyDecodingStrategy._convertFromKebabCase
         case .useDefaultKeys:
-            keyTransform = { key in key }
+            return { key in key }
         case let .custom(converter):
-            keyTransform = { key in
+            return { key in
                 converter(self.codingPath + [XMLKey(stringValue: key, intValue: nil)]).stringValue
             }
         }
-        return transform(keyTransform)
     }
 }

--- a/Sources/XMLCoder/Decoder/XMLDecoderImplementation.swift
+++ b/Sources/XMLCoder/Decoder/XMLDecoderImplementation.swift
@@ -469,3 +469,26 @@ extension XMLDecoderImplementation {
         return result
     }
 }
+
+extension XMLDecoderImplementation {
+    func transformKeyedContainer <Container> (
+        _ transform: ((String) -> String) -> Container
+    ) -> Container {
+        let keyTransform: (String) -> String
+        switch options.keyDecodingStrategy {
+        case .useDefaultKeys:
+            keyTransform = { key in key }
+        case .convertFromSnakeCase:
+            keyTransform = XMLDecoder.KeyDecodingStrategy._convertFromSnakeCase
+        case .convertFromCapitalized:
+            keyTransform = XMLDecoder.KeyDecodingStrategy._convertFromCapitalized
+        case .convertFromKebabCase:
+            keyTransform = XMLDecoder.KeyDecodingStrategy._convertFromKebabCase
+        case let .custom(converter):
+            keyTransform = { key in
+                converter(self.codingPath + [XMLKey(stringValue: key, intValue: nil)]).stringValue
+            }
+        }
+        return transform(keyTransform)
+    }
+}

--- a/Sources/XMLCoder/Decoder/XMLKeyedDecodingContainer.swift
+++ b/Sources/XMLCoder/Decoder/XMLKeyedDecodingContainer.swift
@@ -34,15 +34,13 @@ struct XMLKeyedDecodingContainer<K: CodingKey>: KeyedDecodingContainerProtocol {
         wrapping container: KeyedContainer
     ) {
         self.decoder = decoder
-        self.container = decoder.transformKeyedContainer { keyTransform in
-            let attributes = container.withShared { keyedBox in
-                keyedBox.attributes.map { (keyTransform($0), $1) }
-            }
-            let elements = container.withShared { keyedBox in
-                keyedBox.elements.map { (keyTransform($0), $1) }
-            }
-            let keyedBox = KeyedBox(elements: elements, attributes: attributes)
-            return SharedBox(keyedBox)
+        self.container = container.withShared { keyedBox in
+            return SharedBox(
+                KeyedBox(
+                    elements: keyedBox.elements.map { (decoder.keyTransform($0), $1) },
+                    attributes: keyedBox.attributes.map { (decoder.keyTransform($0), $1) }
+                )
+            )
         }
         codingPath = decoder.codingPath
     }

--- a/Sources/XMLCoder/Decoder/XMLKeyedDecodingContainer.swift
+++ b/Sources/XMLCoder/Decoder/XMLKeyedDecodingContainer.swift
@@ -34,14 +34,11 @@ struct XMLKeyedDecodingContainer<K: CodingKey>: KeyedDecodingContainerProtocol {
         wrapping container: KeyedContainer
     ) {
         self.decoder = decoder
-        self.container = container.withShared { keyedBox in
-            return SharedBox(
-                KeyedBox(
-                    elements: keyedBox.elements.map { (decoder.keyTransform($0), $1) },
-                    attributes: keyedBox.attributes.map { (decoder.keyTransform($0), $1) }
-                )
-            )
+        container.withShared {
+            $0.elements = .init($0.elements.map { (decoder.keyTransform($0), $1) })
+            $0.attributes = .init($0.attributes.map { (decoder.keyTransform($0), $1) })
         }
+        self.container = container
         codingPath = decoder.codingPath
     }
 


### PR DESCRIPTION
This PR moves key transformation logic from the initializers of `XMLChoiceDecodingContainer` and `XMLKeyedDecodingContainer` onto `XMLDecoderImplementation`.

This moves a few things closer to home (`options.keyDecodingStrategy` and `codingPath`), while generalizing it (and thereby DRY-ing it off) for use by multiple `DecodingContainer` types.